### PR TITLE
add isSuccess checks for all data access outside suspense

### DIFF
--- a/frontend/src/routes/_logged-in/_workspaced/container-registry/index.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/container-registry/index.tsx
@@ -51,7 +51,7 @@ const ListContainerRepositories = () => {
 					]}
 					subText="Store and manage container images for your deployments"
 					actions={() => (
-						<Show when={isAllowedCreate() && (repositoriesQuery.data?.repositories?.length ?? 0) > 0}>
+						<Show when={isAllowedCreate() && repositoriesQuery.isSuccess && (repositoriesQuery.data?.repositories?.length ?? 0) > 0}>
 							<Link
 								href="/container-registry/new"
 								buttonVariant={ButtonVariant.Outlined}

--- a/frontend/src/routes/_logged-in/_workspaced/container-registry/index.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/container-registry/index.tsx
@@ -51,7 +51,13 @@ const ListContainerRepositories = () => {
 					]}
 					subText="Store and manage container images for your deployments"
 					actions={() => (
-						<Show when={isAllowedCreate() && repositoriesQuery.isSuccess && (repositoriesQuery.data?.repositories?.length ?? 0) > 0}>
+						<Show
+							when={
+								isAllowedCreate() &&
+								repositoriesQuery.isSuccess &&
+								(repositoriesQuery.data?.repositories?.length ?? 0) > 0
+							}
+						>
 							<Link
 								href="/container-registry/new"
 								buttonVariant={ButtonVariant.Outlined}

--- a/frontend/src/routes/_logged-in/_workspaced/deployments/index.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/deployments/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/solid-router";
 import { useNavigate } from "@tanstack/solid-router";
 import { Title } from "@solidjs/meta";
-import { createEffect, createMemo, ErrorBoundary, Show } from "solid-js";
+import { createEffect, createMemo, ErrorBoundary, Show, Suspense } from "solid-js";
 import { Deployment, WithId } from "~/bindings";
 import {
 	Button,
@@ -100,7 +100,13 @@ const ListDeploymentsPage = () => {
 					]}
 					subText="A deployment represents a containerized application running on a runner."
 					actions={() => (
-						<Show when={isAllowedCreate() && (deploymentsQuery.data?.deployments?.length ?? 0) > 0}>
+						<Show
+							when={
+								isAllowedCreate() &&
+								deploymentsQuery.isSuccess &&
+								(deploymentsQuery.data?.deployments?.length ?? 0) > 0
+							}
+						>
 							<Link href="/deployments/new" buttonVariant={ButtonVariant.Outlined} external={false}>
 								Create Deployment
 							</Link>
@@ -119,8 +125,7 @@ const ListDeploymentsPage = () => {
 							</div>
 						)}
 					>
-						<Show
-							when={!deploymentsQuery.isPending}
+						<Suspense
 							fallback={
 								<div class="flex items-center justify-center gap-2 py-16 text-grey">
 									<LoadingSpinner size={20} />
@@ -170,7 +175,7 @@ const ListDeploymentsPage = () => {
 									showGoToPage={false}
 								/>
 							</Show>
-						</Show>
+						</Suspense>
 					</ErrorBoundary>
 				</PageContainerBody>
 			</PageContainer>

--- a/frontend/src/routes/_logged-in/_workspaced/domains/index.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/domains/index.tsx
@@ -185,7 +185,7 @@ const ListDomainsPage = () => {
 					]}
 					subText="Configure custom domains to route traffic to your deployments."
 					actions={() => (
-						<Show when={isCreateAllowed() && (domainsQuery.data?.domains?.length ?? 0) > 0}>
+						<Show when={isCreateAllowed() && domainsQuery.isSuccess && (domainsQuery.data?.domains?.length ?? 0) > 0}>
 							<Link href="/domains/new" buttonVariant={ButtonVariant.Outlined} external={false}>
 								Add Domain
 							</Link>

--- a/frontend/src/routes/_logged-in/_workspaced/domains/index.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/domains/index.tsx
@@ -185,7 +185,13 @@ const ListDomainsPage = () => {
 					]}
 					subText="Configure custom domains to route traffic to your deployments."
 					actions={() => (
-						<Show when={isCreateAllowed() && domainsQuery.isSuccess && (domainsQuery.data?.domains?.length ?? 0) > 0}>
+						<Show
+							when={
+								isCreateAllowed() &&
+								domainsQuery.isSuccess &&
+								(domainsQuery.data?.domains?.length ?? 0) > 0
+							}
+						>
 							<Link href="/domains/new" buttonVariant={ButtonVariant.Outlined} external={false}>
 								Add Domain
 							</Link>

--- a/frontend/src/routes/_logged-in/_workspaced/profile/api-tokens/index.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/profile/api-tokens/index.tsx
@@ -54,7 +54,7 @@ const ListApiTokens = () => {
 					]}
 					subText="Programmatic access tokens for the Patr API"
 					actions={() => (
-						<Show when={(apiTokensQuery.data?.tokens?.length ?? 0) > 0}>
+						<Show when={apiTokensQuery.isSuccess && (apiTokensQuery.data?.tokens?.length ?? 0) > 0}>
 							<Link
 								href="/profile/api-tokens/new"
 								buttonVariant={ButtonVariant.Outlined}


### PR DESCRIPTION
This fixes the flickering caused when switching pages after solid-query PR. Here's an explanation:

```
  actions={() => (
      <Show when={isAllowedCreate() && (repositoriesQuery.data?.repositories?.length ?? 0) > 0}>
```
This `query.data` is being done outside of suspense boundry. adding a `isSuccedd` check ensures that the access doesn't happen before the data loads