### PR TITLE
add cli upgrade, uninstall, install.sh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,12 @@ jobs:
       major: ${{ steps.v.outputs.major }}
       minor: ${{ steps.v.outputs.minor }}
       short_sha: ${{ steps.v.outputs.short_sha }}
+      build_version: ${{ steps.v.outputs.build_version }}
+      beta_num: ${{ steps.v.outputs.beta_num }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Extract version from Cargo.toml
         id: v
@@ -24,10 +28,35 @@ jobs:
           MINOR=$(echo "$VERSION" | cut -d. -f1-2)
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
 
+          # Channel-specific semver baked into the binary as `PATR_BUILD_VERSION`.
+          # Matches the GH release tag scheme:
+          #   master  -> 0.18.0
+          #   staging -> 0.18.0-beta.N  (N = next unused beta index)
+          #   develop -> 0.18.0-alpha.<run_number>
+          BETA_NUM=""
+          case "${{ github.ref_name }}" in
+            master)
+              BUILD_VERSION="$VERSION"
+              ;;
+            staging)
+              # Find the next beta number by counting existing beta tags for this version.
+              BETA_NUM=1
+              while git tag -l "v${VERSION}-beta.${BETA_NUM}" | grep -q .; do
+                BETA_NUM=$((BETA_NUM + 1))
+              done
+              BUILD_VERSION="${VERSION}-beta.${BETA_NUM}"
+              ;;
+            develop)
+              BUILD_VERSION="${VERSION}-alpha.${{ github.run_number }}"
+              ;;
+          esac
+
           echo "full=$VERSION" >> "$GITHUB_OUTPUT"
           echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
           echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
+          echo "beta_num=$BETA_NUM" >> "$GITHUB_OUTPUT"
 
       - name: Reject duplicate version on stable
         if: github.ref_name == 'master'
@@ -175,21 +204,46 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Standard binaries — shipped via the curl installer + direct download.
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-24.04
             artifact_name: patr-linux-amd64
             binary_name: patr
             archive_ext: tar.gz
+            features: ""
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
             artifact_name: patr-linux-arm64
             binary_name: patr
             archive_ext: tar.gz
+            features: ""
           - target: aarch64-apple-darwin
             runner: macos-14
             artifact_name: patr-darwin-arm64
             binary_name: patr
             archive_ext: zip
+            features: ""
+          # Homebrew-tapped binaries — built with `package-managed` so
+          # `patr upgrade` and `patr uninstall` hard-refuse. Consumed by the
+          # homebrew formula.
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+            artifact_name: patr-linux-amd64-brew
+            binary_name: patr
+            archive_ext: tar.gz
+            features: package-managed
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            artifact_name: patr-linux-arm64-brew
+            binary_name: patr
+            archive_ext: tar.gz
+            features: package-managed
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            artifact_name: patr-darwin-arm64-brew
+            binary_name: patr
+            archive_ext: zip
+            features: package-managed
     steps:
       - uses: actions/checkout@v6
         with:
@@ -218,10 +272,16 @@ jobs:
           VITE_BUILD_TARGET: csr
 
       - name: Build CLI
-        run: cargo build --release --package cli --locked
+        run: |
+          if [ -n "${{ matrix.features }}" ]; then
+            cargo build --release --package cli --locked --features "${{ matrix.features }}"
+          else
+            cargo build --release --package cli --locked
+          fi
         env:
           PATR_BUILD_CHANNEL: ${{ github.ref_name == 'master' && 'stable' || github.ref_name == 'staging' && 'beta' || 'alpha' }}
           PATR_BUILD_SHA: ${{ github.sha }}
+          PATR_BUILD_VERSION: ${{ needs.version.outputs.build_version }}
 
       - name: Package binary (tar.gz)
         if: matrix.archive_ext == 'tar.gz'
@@ -459,6 +519,10 @@ jobs:
           merge-multiple: true
           path: artifacts
 
+      - name: Write version.txt
+        working-directory: artifacts
+        run: echo "${{ needs.version.outputs.build_version }}" > version.txt
+
       - name: Generate SHA256 checksums
         working-directory: artifacts
         run: |
@@ -474,6 +538,7 @@ jobs:
           BRANCH="${{ github.ref_name }}"
           VERSION="${{ needs.version.outputs.full }}"
           SHORT_SHA="${{ needs.version.outputs.short_sha }}"
+          BETA_NUM="${{ needs.version.outputs.beta_num }}"
 
           case "$BRANCH" in
             master)
@@ -482,11 +547,6 @@ jobs:
               NAME="Patr CLI v${VERSION}"
               ;;
             staging)
-              # Find the next beta number by counting existing beta tags for this version
-              BETA_NUM=1
-              while git tag -l "v${VERSION}-beta.${BETA_NUM}" | grep -q .; do
-                BETA_NUM=$((BETA_NUM + 1))
-              done
               TAG="v${VERSION}-beta.${BETA_NUM}"
               PRERELEASE=true
               NAME="Patr CLI v${VERSION}-beta.${BETA_NUM}"
@@ -550,21 +610,18 @@ jobs:
 
           case "$BRANCH" in
             master)
-              BREW_VERSION="${VERSION}"
               FORMULA="cli"
               CLASS="Cli"
               CONFLICTS_A="alpha"
               CONFLICTS_B="beta"
               ;;
             staging)
-              BREW_VERSION="${TAG#v}"
               FORMULA="beta"
               CLASS="Beta"
               CONFLICTS_A="cli"
               CONFLICTS_B="alpha"
               ;;
             develop)
-              BREW_VERSION="${VERSION}-alpha.${{ github.run_number }}"
               FORMULA="alpha"
               CLASS="Alpha"
               CONFLICTS_A="cli"
@@ -575,6 +632,9 @@ jobs:
               exit 1
               ;;
           esac
+
+          # Reuse the same semver string the binary itself carries.
+          BREW_VERSION="${{ needs.version.outputs.build_version }}"
 
           echo "brew_version=$BREW_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
@@ -592,10 +652,12 @@ jobs:
 
       - name: Compute checksums
         id: shas
+        # Homebrew installs the `-brew` variants (built with
+        # `--features no-self-update`), so hash those, not the standard ones.
         run: |
-          echo "linux_amd64=$(sha256sum /tmp/assets/patr-linux-amd64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          echo "linux_arm64=$(sha256sum /tmp/assets/patr-linux-arm64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          echo "darwin_arm64=$(sha256sum /tmp/assets/patr-darwin-arm64.zip | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "linux_amd64=$(sha256sum /tmp/assets/patr-linux-amd64-brew.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "linux_arm64=$(sha256sum /tmp/assets/patr-linux-arm64-brew.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "darwin_arm64=$(sha256sum /tmp/assets/patr-darwin-arm64-brew.zip | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Generate and push formula
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -653,7 +653,7 @@ jobs:
       - name: Compute checksums
         id: shas
         # Homebrew installs the `-brew` variants (built with
-        # `--features no-self-update`), so hash those, not the standard ones.
+        # `--features package-managed`), so hash those, not the standard ones.
         run: |
           echo "linux_amd64=$(sha256sum /tmp/assets/patr-linux-amd64-brew.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
           echo "linux_arm64=$(sha256sum /tmp/assets/patr-linux-arm64-brew.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "evenBetterToml.formatter.reorderKeys": true,
+    "evenBetterToml.formatter.alignEntries": true,
+    "evenBetterToml.formatter.reorderInlineTables": true,
+    "evenBetterToml.formatter.reorderArrays": false,
+    "evenBetterToml.formatter.columnWidth": 200,
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "dirs",
  "docker",
  "either",
+ "flate2",
  "futures",
  "headers",
  "http 1.4.0",
@@ -1376,11 +1377,17 @@ dependencies = [
  "preprocess",
  "rand 0.10.1",
  "reqwest 0.13.2",
+ "self-replace",
+ "semver",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "serde_qs",
  "serde_yaml2",
+ "sha2 0.11.0",
+ "strum 0.28.0",
+ "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -1390,6 +1397,7 @@ dependencies = [
  "typed-builder",
  "url",
  "uzers",
+ "zip",
 ]
 
 [[package]]
@@ -2464,6 +2472,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -5581,6 +5590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6348,7 +6368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6933,6 +6953,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -8127,7 +8153,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.1",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,12 @@ headers                        = { default-features = false, version = "0.4" }
 hex                            = { default-features = false, version = "0.4" }
 hickory-resolver               = { default-features = false, version = "0.25" }
 http                           = { default-features = false, version = "1" }
-inventory                      = { default-features = false, version = "0.3" }
 http-body                      = { default-features = false, version = "1" }
 httparse                       = { default-features = false, version = "1" }
 hyper                          = { default-features = false, version = "1" }
 if-addrs                       = { default-features = false, version = "0.15" }
 inquire                        = { default-features = false, version = "0.9" }
+inventory                      = { default-features = false, version = "0.3" }
 ipinfo                         = { default-features = false, version = "3" }
 ipnetwork                      = { default-features = false, version = "0.20" }
 jsonwebtoken                   = { default-features = false, version = "10" }
@@ -99,6 +99,7 @@ rust-s3                        = { default-features = false, version = "0.37" }
 rustis                         = { default-features = false, version = "0.19" }
 rustls                         = { default-features = false, version = "0.23" }
 schemars                       = { default-features = false, version = "1" }
+self-replace                   = { default-features = false, version = "1" }
 semver                         = { default-features = false, version = "1" }
 serde                          = { default-features = false, version = "1" }
 serde_json                     = { default-features = false, version = "1" }
@@ -136,6 +137,7 @@ uzers                          = { default-features = false, version = "0.12" }
 wiremock                       = { default-features = false, version = "0.6" }
 woothee                        = { default-features = false, version = "0.13" }
 worker                         = { default-features = false, version = "0.7" }
+zip                            = { default-features = false, version = "8" }
 
 [workspace.dev-dependencies]
 k8s-openapi = { features = ["latest"] }

--- a/assets/cli/homebrew/formula.rb
+++ b/assets/cli/homebrew/formula.rb
@@ -6,19 +6,21 @@ class {{CLASS}} < Formula
   conflicts_with "{{CONFLICTS_A}}", because: "both install the patr binary"
   conflicts_with "{{CONFLICTS_B}}", because: "both install the patr binary"
 
+  # Homebrew-specific binaries are built with `--features package-managed` so
+  # `patr upgrade` and `patr uninstall` hard-refuse and defer to `brew`.
   on_macos do
     if Hardware::CPU.arm?
-      url "{{BASE_URL}}/patr-darwin-arm64.zip"
+      url "{{BASE_URL}}/patr-darwin-arm64-brew.zip"
       sha256 "{{SHA_DARWIN_ARM64}}"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "{{BASE_URL}}/patr-linux-arm64.tar.gz"
+      url "{{BASE_URL}}/patr-linux-arm64-brew.tar.gz"
       sha256 "{{SHA_LINUX_ARM64}}"
     else
-      url "{{BASE_URL}}/patr-linux-amd64.tar.gz"
+      url "{{BASE_URL}}/patr-linux-amd64-brew.tar.gz"
       sha256 "{{SHA_LINUX_AMD64}}"
     end
   end

--- a/assets/cli/install.sh
+++ b/assets/cli/install.sh
@@ -1,0 +1,213 @@
+#!/bin/sh
+#
+# Patr CLI installer.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/patr-cloud/patr/master/assets/cli/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/patr-cloud/patr/master/assets/cli/install.sh | sh -s -- --channel beta
+#   curl -fsSL https://raw.githubusercontent.com/patr-cloud/patr/master/assets/cli/install.sh | sh -s -- --prefix $HOME/.local/bin
+
+set -eu
+
+REPO="patr-cloud/patr"
+CHANNEL="alpha" # stable isn't ready yet, so default to alpha for now
+PREFIX=""
+
+usage() {
+	cat <<EOF >&2
+Patr CLI installer
+
+Usage:
+  install.sh [--channel stable|beta|alpha] [--prefix <dir>]
+
+Options:
+  --channel <name>   Release channel to install (default: alpha until stable is ready).
+  --prefix <dir>     Install to <dir>/patr. Default: /usr/local/bin (uses sudo).
+  -h, --help         Show this help.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--channel)
+			[ $# -ge 2 ] || { echo "error: --channel requires an argument" >&2; exit 1; }
+			CHANNEL="$2"
+			shift 2
+			;;
+		--prefix)
+			[ $# -ge 2 ] || { echo "error: --prefix requires an argument" >&2; exit 1; }
+			PREFIX="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "error: unknown argument: $1" >&2
+			usage
+			exit 1
+			;;
+	esac
+done
+
+case "$CHANNEL" in
+	stable|beta|alpha) ;;
+	*)
+		echo "error: --channel must be one of: stable, beta, alpha (got '$CHANNEL')" >&2
+		exit 1
+		;;
+esac
+
+require() {
+	command -v "$1" >/dev/null 2>&1 || { echo "error: required command not found on PATH: $1" >&2; exit 1; }
+}
+
+require curl
+require uname
+require mktemp
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS-$ARCH" in
+	Linux-x86_64)   PLATFORM="linux-amd64";  EXT="tar.gz" ;;
+	Linux-aarch64)  PLATFORM="linux-arm64";  EXT="tar.gz" ;;
+	Linux-arm64)    PLATFORM="linux-arm64";  EXT="tar.gz" ;;
+	Darwin-arm64)   PLATFORM="darwin-arm64"; EXT="zip"    ;;
+	*)
+		echo "error: unsupported platform: $OS $ARCH" >&2
+		echo "supported: Linux x86_64, Linux aarch64/arm64, macOS arm64" >&2
+		exit 1
+		;;
+esac
+
+if [ "$EXT" = "tar.gz" ]; then
+	require tar
+else
+	require unzip
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+	SHA_CHECK="sha256sum -c"
+elif command -v shasum >/dev/null 2>&1; then
+	SHA_CHECK="shasum -a 256 -c"
+else
+	echo "error: need either sha256sum or shasum on PATH" >&2
+	exit 1
+fi
+
+# Resolve release tag for the chosen channel via the GitHub REST API.
+API="https://api.github.com/repos/$REPO/releases"
+
+case "$CHANNEL" in
+	stable)
+		TAG="$(curl -fsSL "$API/latest" \
+			| grep -o '"tag_name": *"[^"]*"' \
+			| head -n 1 \
+			| sed -E 's/.*"tag_name": *"([^"]+)"/\1/')"
+		if [ -z "${TAG:-}" ]; then
+			echo "error: could not resolve latest stable release on $REPO" >&2
+			exit 1
+		fi
+		;;
+	alpha)
+		TAG="$(curl -fsSL "$API/tags/alpha" \
+			| grep -o '"tag_name": *"[^"]*"' \
+			| head -n 1 \
+			| sed -E 's/.*"tag_name": *"([^"]+)"/\1/')"
+		if [ -z "${TAG:-}" ]; then
+			echo "error: no rolling alpha release found on $REPO" >&2
+			exit 1
+		fi
+		;;
+	beta)
+		# Paginate through the release list until we find the newest beta or
+		# reach the end of the list (a short page).
+		TAG=""
+		PAGE=1
+		while : ; do
+			PAGE_JSON="$(curl -fsSL "$API?per_page=100&page=$PAGE")"
+			TAG="$(printf '%s' "$PAGE_JSON" \
+				| grep -o '"tag_name": *"v[^"]*-beta\.[^"]*"' \
+				| head -n 1 \
+				| sed -E 's/.*"tag_name": *"([^"]+)"/\1/')"
+			if [ -n "$TAG" ]; then
+				break
+			fi
+			# `grep -c` exits 1 on no match; `|| true` keeps `set -e` happy.
+			NUM="$(printf '%s' "$PAGE_JSON" | grep -c '"tag_name":' || true)"
+			if [ "$NUM" -lt 100 ]; then
+				break
+			fi
+			PAGE=$((PAGE + 1))
+		done
+		if [ -z "$TAG" ]; then
+			echo "error: no beta release found on $REPO" >&2
+			exit 1
+		fi
+		;;
+esac
+
+ARTIFACT="patr-${PLATFORM}.${EXT}"
+BASE_URL="https://github.com/$REPO/releases/download/$TAG"
+ARCHIVE_URL="$BASE_URL/$ARTIFACT"
+SHA_URL="$BASE_URL/$ARTIFACT.sha256sum"
+
+echo "Patr CLI installer (channel: $CHANNEL, release: $TAG)"
+echo ""
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Downloading $ARTIFACT..."
+curl -fSL --progress-bar "$ARCHIVE_URL" -o "$TMPDIR/$ARTIFACT"
+curl -fsSL "$SHA_URL" -o "$TMPDIR/$ARTIFACT.sha256sum"
+
+printf "Verifying checksum... "
+( cd "$TMPDIR" && $SHA_CHECK "$ARTIFACT.sha256sum" >/dev/null )
+echo "ok"
+
+# Extract.
+if [ "$EXT" = "tar.gz" ]; then
+	tar -xzf "$TMPDIR/$ARTIFACT" -C "$TMPDIR"
+else
+	unzip -q "$TMPDIR/$ARTIFACT" -d "$TMPDIR"
+fi
+
+if [ ! -f "$TMPDIR/patr" ]; then
+	echo "error: archive did not contain an expected 'patr' binary" >&2
+	exit 1
+fi
+
+# Install.
+if [ -n "$PREFIX" ]; then
+	mkdir -p "$PREFIX"
+	install -m 0755 "$TMPDIR/patr" "$PREFIX/patr"
+	DEST="$PREFIX/patr"
+else
+	DEST="/usr/local/bin/patr"
+	echo ""
+	echo "Installing to $DEST (may prompt for your password)."
+	sudo install -m 0755 "$TMPDIR/patr" "$DEST"
+fi
+
+echo ""
+echo "Installed Patr CLI to $DEST"
+echo ""
+
+# PATH hint (only needed for --prefix outside a standard bin dir).
+if [ -n "$PREFIX" ]; then
+	case ":$PATH:" in
+		*":$PREFIX:"*)
+			;;
+		*)
+			echo "warning: $PREFIX is not on your PATH."
+			echo "Add it to your shell profile, e.g.:"
+			echo "    export PATH=\"$PREFIX:\$PATH\""
+			echo ""
+			;;
+	esac
+fi
+
+echo "Run \`patr --help\` to get started."

--- a/assets/cli/install.sh
+++ b/assets/cli/install.sh
@@ -88,6 +88,27 @@ else
 	require unzip
 fi
 
+# Refuse to overwrite an existing install at the target path. `patr upgrade` is
+# the one path that keeps the binary and the CLI's persisted target channel in
+# sync; letting the script replace the binary behind its back causes the two to
+# drift.
+if [ -n "$PREFIX" ]; then
+	DEST="$PREFIX/patr"
+else
+	DEST="/usr/local/bin/patr"
+fi
+if [ -e "$DEST" ]; then
+	echo "error: patr is already installed at $DEST" >&2
+	echo "" >&2
+	echo "To update to the latest release, run:" >&2
+	echo "    patr upgrade" >&2
+	echo "" >&2
+	echo "To reinstall from scratch, run:" >&2
+	echo "    patr uninstall" >&2
+	echo "and then re-run this install script." >&2
+	exit 1
+fi
+
 if command -v sha256sum >/dev/null 2>&1; then
 	SHA_CHECK="sha256sum -c"
 elif command -v shasum >/dev/null 2>&1; then
@@ -183,10 +204,8 @@ fi
 # Install.
 if [ -n "$PREFIX" ]; then
 	mkdir -p "$PREFIX"
-	install -m 0755 "$TMPDIR/patr" "$PREFIX/patr"
-	DEST="$PREFIX/patr"
+	install -m 0755 "$TMPDIR/patr" "$DEST"
 else
-	DEST="/usr/local/bin/patr"
 	echo ""
 	echo "Installing to $DEST (may prompt for your password)."
 	sudo install -m 0755 "$TMPDIR/patr" "$DEST"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,14 @@ workspace = true
 name = "patr"
 path = "src/main.rs"
 
+[features]
+default = []
+# Signals that this build's install/uninstall/upgrade lifecycle is owned by an
+# external package manager (Homebrew, distro packages, etc.). `patr upgrade`
+# and `patr uninstall` refuse to modify the installation and tell the user to
+# use their package manager instead.
+package-managed = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -25,6 +33,7 @@ crossterm           = { workspace = true, features = [] }
 dirs                = { workspace = true, features = [] }
 docker              = { workspace = true, features = [] }
 either              = { workspace = true, features = ["serde"] }
+flate2              = { workspace = true, features = ["default"] }
 futures             = { workspace = true, features = ["default"] }
 headers             = { workspace = true, features = [] }
 http                = { workspace = true, features = ["default"] }
@@ -36,11 +45,17 @@ open                = { workspace = true, features = [] }
 preprocess          = { workspace = true, features = [] }
 rand                = { workspace = true, features = ["default"] }
 reqwest             = { workspace = true, features = ["default", "json"] }
+self-replace        = { workspace = true, features = [] }
+semver              = { workspace = true, features = [] }
 serde               = { workspace = true, features = ["default", "derive"] }
 serde_json          = { workspace = true, features = ["default"] }
 serde_path_to_error = { workspace = true, features = [] }
 serde_qs            = { workspace = true, features = [] }
 serde_yaml2         = { workspace = true, features = [] }
+sha2                = { workspace = true, features = ["default"] }
+strum               = { workspace = true, features = ["derive"] }
+tar                 = { workspace = true, features = [] }
+tempfile            = { workspace = true, features = [] }
 thiserror           = { workspace = true, features = ["default"] }
 time                = { workspace = true, features = ["default", "serde-human-readable"] }
 tokio               = { workspace = true, features = ["default", "full"] }
@@ -50,6 +65,7 @@ tracing-subscriber  = { workspace = true, features = ["default"] }
 typed-builder       = { workspace = true, features = [] }
 url                 = { workspace = true, features = ["default"] }
 uzers               = { workspace = true, features = ["default"] }
+zip                 = { workspace = true, features = ["deflate"] }
 
 [build-dependencies]
 time = { workspace = true, features = [] }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,11 +1,15 @@
-//! Forwards `PATR_BUILD_SHA` and sets `PATR_BUILD_DATE` at compile time
-//! for use in `patr --version`.
+//! Forwards `PATR_BUILD_SHA` + `PATR_BUILD_CHANNEL` + `PATR_BUILD_VERSION` and
+//! sets `PATR_BUILD_DATE` at compile time for use in `patr --version` and
+//! `patr upgrade`.
 
 use time::OffsetDateTime;
 
 fn main() {
-	if let Ok(sha) = std::env::var("PATR_BUILD_SHA") {
-		println!("cargo:rustc-env=PATR_BUILD_SHA={sha}");
+	for key in ["PATR_BUILD_SHA", "PATR_BUILD_CHANNEL", "PATR_BUILD_VERSION"] {
+		println!("cargo:rerun-if-env-changed={key}");
+		if let Ok(value) = std::env::var(key) {
+			println!("cargo:rustc-env={key}={value}");
+		}
 	}
 
 	let now = OffsetDateTime::now_utc();

--- a/cli/src/commands/apply/deployment.rs
+++ b/cli/src/commands/apply/deployment.rs
@@ -8,6 +8,8 @@ use models::{
 
 use crate::prelude::*;
 
+/// Apply an IaaC deployment resource — creating the deployment on Patr and
+/// associating it with a runner + registry image.
 pub async fn apply(
 	workspace_id: Uuid,
 	token: BearerToken,

--- a/cli/src/commands/apply/domain.rs
+++ b/cli/src/commands/apply/domain.rs
@@ -2,6 +2,7 @@ use models::{api::workspace::domain::*, iaac::*, utils::BearerToken};
 
 use crate::prelude::*;
 
+/// Apply an IaaC domain resource — registering the domain on the workspace.
 pub async fn apply(
 	workspace_id: Uuid,
 	token: BearerToken,

--- a/cli/src/commands/apply/managed_url.rs
+++ b/cli/src/commands/apply/managed_url.rs
@@ -6,6 +6,8 @@ use models::{
 
 use crate::prelude::*;
 
+/// Apply an IaaC managed-URL resource — wiring an external URL to a
+/// deployment or domain.
 pub async fn apply(
 	workspace_id: Uuid,
 	token: BearerToken,

--- a/cli/src/commands/apply/mod.rs
+++ b/cli/src/commands/apply/mod.rs
@@ -35,10 +35,10 @@ pub async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/apply/mod.rs
+++ b/cli/src/commands/apply/mod.rs
@@ -14,6 +14,7 @@ mod domain;
 /// workspace
 mod managed_url;
 
+/// Args for `patr apply`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct Args {
 	/// The filename of the configuration file to apply
@@ -30,6 +31,7 @@ pub struct Args {
 	pub dry_run: bool,
 }
 
+/// Apply an IaaC config file to the workspace.
 pub async fn execute(
 	args: Args,
 	global_args: GlobalArgs,

--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -16,12 +16,12 @@ pub(super) async fn execute(
 			.into_result();
 	}
 
-	let access_token = match state {
-		AppState::LoggedIn {
+	let access_token = match state.auth {
+		AuthState::LoggedIn {
 			token,
 			current_workspace: _,
 		} => token,
-		AppState::LoggedOut => {
+		AuthState::LoggedOut => {
 			return Err(AppError::NotLoggedIn);
 		}
 	};

--- a/cli/src/commands/info.rs
+++ b/cli/src/commands/info.rs
@@ -21,7 +21,7 @@ pub(super) async fn execute(
 			token,
 			current_workspace: _,
 		} => token,
-		AuthState::LoggedOut => {
+		AuthState::LoggedOut {} => {
 			return Err(AppError::NotLoggedIn);
 		}
 	};

--- a/cli/src/commands/login.rs
+++ b/cli/src/commands/login.rs
@@ -8,7 +8,7 @@ use crate::prelude::*;
 /// A command that logs the user into their Patr account.
 pub(super) async fn execute(
 	global_args: GlobalArgs,
-	_: AppState,
+	mut state: AppState,
 ) -> Result<CommandOutput, AppError> {
 	// Prompt for the token
 	let token = global_args.token.unwrap_or_else(|| {
@@ -68,12 +68,12 @@ pub(super) async fn execute(
 	.next()
 	.map(|workspace| workspace.id);
 
-	// Save the authenticated state
-	AppState::LoggedIn {
+	// Save the authenticated state (preserving any existing target_channel).
+	state.auth = AuthState::LoggedIn {
 		token: BearerToken::from_str(&token)?,
 		current_workspace,
-	}
-	.save()?;
+	};
+	state.save()?;
 
 	CommandOutput::builder()
 		.text(format!(

--- a/cli/src/commands/logout.rs
+++ b/cli/src/commands/logout.rs
@@ -16,7 +16,7 @@ pub(super) async fn execute(
 	}
 
 	// Drop the auth while preserving any other preferences (target_channel etc).
-	state.auth = AuthState::LoggedOut;
+	state.auth = AuthState::LoggedOut {};
 	state.save()?;
 
 	CommandOutput::builder()

--- a/cli/src/commands/logout.rs
+++ b/cli/src/commands/logout.rs
@@ -3,17 +3,21 @@ use models::ApiSuccessResponseBody;
 use crate::prelude::*;
 
 /// A command that logs the user out of their Patr account.
-pub(super) async fn execute(_args: GlobalArgs, state: AppState) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn { .. } = state else {
+pub(super) async fn execute(
+	_args: GlobalArgs,
+	mut state: AppState,
+) -> Result<CommandOutput, AppError> {
+	if !state.is_logged_in() {
 		return CommandOutput::builder()
 			.text("You are not logged in.")
 			.json(ApiSuccessResponseBody::empty().to_json_value())
 			.build()
 			.into_result();
-	};
+	}
 
-	// Save the logged out state
-	AppState::LoggedOut.save()?;
+	// Drop the auth while preserving any other preferences (target_channel etc).
+	state.auth = AuthState::LoggedOut;
+	state.save()?;
 
 	CommandOutput::builder()
 		.text("You have been logged out. Don't forget to revoke your API token!")

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -11,6 +11,10 @@ mod info;
 mod login;
 /// The command to logout of your Patr account.
 mod logout;
+/// The command to uninstall the Patr CLI from this host.
+mod uninstall;
+/// The command to upgrade the Patr CLI in place.
+mod upgrade;
 /// All commands that are meant for a workspace.
 mod workspaced;
 
@@ -67,6 +71,12 @@ pub enum GlobalCommand {
 	/// Apply a configuration file to the current workspace.
 	#[command(name = "apply")]
 	Apply(apply::Args),
+	/// Upgrade the Patr CLI in place.
+	#[command(alias = "update", alias = "self-update")]
+	Upgrade(upgrade::Args),
+	/// Uninstall the Patr CLI from this host.
+	#[command(alias = "delete")]
+	Uninstall(uninstall::Args),
 	/// All the commands that are meant for a workspace
 	#[command(flatten)]
 	Workspaced(WorkspacedCommand),
@@ -82,6 +92,8 @@ pub async fn execute(
 		GlobalCommand::Logout => logout::execute(global_args, state).await,
 		GlobalCommand::Info => info::execute(global_args, state).await,
 		GlobalCommand::Apply(args) => apply::execute(args, global_args, state).await,
+		GlobalCommand::Upgrade(args) => upgrade::execute(args, global_args, state).await,
+		GlobalCommand::Uninstall(args) => uninstall::execute(args, global_args, state).await,
 		GlobalCommand::Workspaced(commands) => {
 			workspaced::execute(commands, global_args, state).await
 		}
@@ -90,26 +102,24 @@ pub async fn execute(
 
 /// Builds the version string shown by `patr --version`.
 ///
-/// SHA and date are set by `build.rs` from git/system. Channel is set by CI
-/// via `PATR_BUILD_CHANNEL` env var; local builds fall back to `-dev`.
+/// CI bakes `PATR_BUILD_VERSION` (full semver, e.g. `0.19.0-alpha.142`),
+/// `PATR_BUILD_CHANNEL`, `PATR_BUILD_SHA`, and `PATR_BUILD_DATE` into the
+/// binary. Local builds fall back to `CARGO_PKG_VERSION-dev`.
 fn build_version() -> String {
-	let version = env!("CARGO_PKG_VERSION");
+	let version = constants::PATR_BUILD_VERSION;
 	let channel = option_env!("PATR_BUILD_CHANNEL");
 	let sha = option_env!("PATR_BUILD_SHA");
 	let date = option_env!("PATR_BUILD_DATE");
 	let os = std::env::consts::OS;
 	let arch = std::env::consts::ARCH;
 
-	let version_str = match channel {
-		Some("alpha") => format!("{version}-alpha"),
-		Some("beta") => format!("{version}-beta"),
-		Some("stable") => version.to_string(),
-		_ => return format!("{version}-dev {os}/{arch}"),
-	};
+	if channel.is_none() {
+		return format!("{version}-dev {os}/{arch}");
+	}
 
 	match (sha, date) {
-		(Some(sha), Some(date)) => format!("{version_str} ({sha} {date}) {os}/{arch}"),
-		(None, Some(date)) => format!("{version_str} ({date}) {os}/{arch}"),
-		_ => format!("{version_str} {os}/{arch}"),
+		(Some(sha), Some(date)) => format!("{version} ({sha} {date}) {os}/{arch}"),
+		(None, Some(date)) => format!("{version} ({date}) {os}/{arch}"),
+		_ => format!("{version} {os}/{arch}"),
 	}
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -82,6 +82,7 @@ pub enum GlobalCommand {
 	Workspaced(WorkspacedCommand),
 }
 
+/// Dispatch a top-level CLI command to its handler.
 pub async fn execute(
 	command: GlobalCommand,
 	global_args: GlobalArgs,

--- a/cli/src/commands/uninstall.rs
+++ b/cli/src/commands/uninstall.rs
@@ -1,0 +1,260 @@
+use std::{io::IsTerminal, path::Path, process::Command};
+
+use clap::Args as ClapArgs;
+use models::ApiSuccessResponseBody;
+use strum::IntoEnumIterator as _;
+
+use crate::prelude::*;
+
+/// Args for `patr uninstall`.
+#[derive(Debug, Clone, ClapArgs)]
+pub struct Args {
+	/// Skip the layer-1 confirmation prompt.
+	#[arg(short = 'y', long = "yes")]
+	pub yes: bool,
+	/// Also tear down resources managed by Patr runners on this host
+	/// (`docker swarm leave --force`). Implies `-y`.
+	#[arg(long)]
+	pub purge: bool,
+}
+
+/// Uninstall the Patr CLI from this host.
+pub async fn execute(
+	args: Args,
+	_global_args: GlobalArgs,
+	_state: AppState,
+) -> Result<CommandOutput, AppError> {
+	if cfg!(feature = "package-managed") {
+		eprintln!("uninstall is disabled for this build of patr");
+		eprintln!("this CLI is managed by your package manager — use it to uninstall");
+		return CommandOutput::builder()
+			.text(String::new())
+			.json(ApiSuccessResponseBody::empty().to_json_value())
+			.build()
+			.into_result();
+	}
+
+	let current_exe = std::env::current_exe()
+		.map_err(|e| AppError::RunnerError(format!("Failed to determine current binary: {e}")))?;
+
+	let cli_config_path = crate::utils::config_local_dir();
+	let runner_configs = RunnerType::iter()
+		.map(|t| (t, crate::utils::runner_config_path(t)))
+		.filter(|(_, p)| p.exists())
+		.collect::<Vec<_>>();
+
+	// Layer 1 confirm (unless -y or --purge).
+	if !args.yes && !args.purge {
+		if !std::io::stdin().is_terminal() {
+			return Err(AppError::RunnerError(
+				"Running in non-TTY mode. Pass -y to confirm uninstall.".to_string(),
+			));
+		}
+		eprintln!("This will remove:");
+		if cli_config_path.exists() {
+			eprintln!("  - CLI config ({})", cli_config_path.display());
+		}
+		for (_, p) in &runner_configs {
+			eprintln!("  - Runner config ({})", p.display());
+		}
+		if !runner_configs.is_empty() && Path::new("/run/systemd/system").exists() {
+			eprintln!("  - Installed systemd services for the above runners, if any");
+		}
+		eprintln!("  - The patr binary at {}", current_exe.display());
+		let confirm = inquire::Confirm::new("Continue?")
+			.with_default(false)
+			.prompt()
+			.expect_tty("Failed to read uninstall confirmation");
+		if !confirm {
+			return Err(AppError::RunnerError("Aborted.".to_string()));
+		}
+	}
+
+	// Layer 2: tear down runner-managed resources (docker swarm).
+	let do_purge = if args.purge {
+		true
+	} else if !std::io::stdin().is_terminal() {
+		false
+	} else {
+		eprintln!();
+		eprintln!("Also tear down resources managed by Patr runners on this host?");
+		eprintln!();
+		eprintln!("This will run `docker swarm leave --force`.");
+		eprintln!();
+		eprintln!("Affected: services managed by this host's Docker swarm");
+		eprintln!("(including Patr deployments running on this runner).");
+		eprintln!(
+			"Not affected: standalone containers running via `docker run` outside the swarm."
+		);
+		eprintln!();
+		inquire::Confirm::new("Continue?")
+			.with_default(false)
+			.prompt()
+			.expect_tty("Failed to read purge confirmation")
+	};
+
+	// Layer 2 runs first, while the runner configs + binary are still present.
+	if do_purge {
+		eprintln!("Running `docker swarm leave --force`...");
+		match Command::new("docker")
+			.args(["swarm", "leave", "--force"])
+			.status()
+		{
+			Ok(status) if status.success() => {}
+			Ok(status) => {
+				eprintln!("docker swarm leave exited with {status} — continuing with uninstall.");
+			}
+			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+				eprintln!("docker not found on PATH — skipping swarm cleanup.");
+			}
+			Err(e) => {
+				eprintln!("Failed to run docker: {e} — continuing with uninstall.");
+			}
+		}
+	}
+
+	// Layer 1: remove installed systemd services for any runner type whose
+	// config we found on disk. Logic mirrors `runner service uninstall` but
+	// runs non-interactively here.
+	if Path::new("/run/systemd/system").exists() {
+		let is_root = uzers::get_current_uid() == 0;
+		if !is_root && !runner_configs.is_empty() {
+			eprintln!(
+				"This will use sudo to stop/remove installed systemd services. You may be prompted for your password."
+			);
+		}
+		for (runner_type, _) in &runner_configs {
+			let runner_type_str = match runner_type {
+				RunnerType::Docker => "docker",
+				RunnerType::Kubernetes => "kubernetes",
+			};
+			let service_name = format!("patr-{runner_type_str}-runner.service");
+			let service_file_path = format!("/etc/systemd/system/{service_name}");
+
+			// Lenient stop.
+			let mut stop_cmd = if is_root {
+				Command::new("systemctl")
+			} else {
+				let mut c = Command::new("sudo");
+				c.arg("systemctl");
+				c
+			};
+			stop_cmd.args(["stop", &service_name]);
+			if let Err(e) = stop_cmd.status() {
+				eprintln!("systemctl stop {service_name}: {e} (continuing)");
+			}
+
+			// Lenient disable.
+			let mut disable_cmd = if is_root {
+				Command::new("systemctl")
+			} else {
+				let mut c = Command::new("sudo");
+				c.arg("systemctl");
+				c
+			};
+			disable_cmd.args(["disable", &service_name]);
+			if let Err(e) = disable_cmd.status() {
+				eprintln!("systemctl disable {service_name}: {e} (continuing)");
+			}
+
+			let rm_ok = if is_root {
+				std::fs::remove_file(&service_file_path)
+					.or_else(|e| {
+						if e.kind() == std::io::ErrorKind::NotFound {
+							Ok(())
+						} else {
+							Err(e)
+						}
+					})
+					.map_err(|e| format!("Failed to remove {service_file_path}: {e}"))
+			} else {
+				Command::new("sudo")
+					.args(["rm", "-f", &service_file_path])
+					.status()
+					.map_err(|e| format!("Failed to run sudo rm: {e}"))
+					.and_then(|s| {
+						if s.success() {
+							Ok(())
+						} else {
+							Err(format!("sudo rm exited with {s}"))
+						}
+					})
+			};
+			if let Err(e) = rm_ok {
+				eprintln!("Warning: {e}");
+			}
+		}
+
+		// One daemon-reload after all services removed.
+		if !runner_configs.is_empty() {
+			let _ = if is_root {
+				Command::new("systemctl")
+			} else {
+				let mut c = Command::new("sudo");
+				c.arg("systemctl");
+				c
+			}
+			.arg("daemon-reload")
+			.status();
+		}
+	}
+
+	// Remove runner config files.
+	for (_, config_path) in &runner_configs {
+		if let Err(e) = std::fs::remove_file(config_path) &&
+			e.kind() != std::io::ErrorKind::NotFound
+		{
+			eprintln!("Warning: failed to remove {}: {e}", config_path.display());
+		}
+	}
+
+	// Remove the CLI state file.
+	if cli_config_path.exists() &&
+		let Err(e) = std::fs::remove_file(&cli_config_path)
+	{
+		eprintln!(
+			"Warning: failed to remove {}: {e}",
+			cli_config_path.display()
+		);
+	}
+
+	// Remove the binary last (it's the one executing this code). Try
+	// self_delete first — falls back to `sudo rm` when the path is
+	// root-owned (typical for /usr/local/bin).
+	match self_replace::self_delete() {
+		Ok(()) => {}
+		Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+			eprintln!(
+				"Removing {} (may prompt for your password).",
+				current_exe.display()
+			);
+			let status = Command::new("sudo")
+				.args(["rm", "-f"])
+				.arg(&current_exe)
+				.status()
+				.map_err(|e| match e.kind() {
+					std::io::ErrorKind::NotFound => AppError::RunnerError(
+						"sudo not found on PATH. Remove the binary manually.".to_string(),
+					),
+					_ => AppError::RunnerError(format!("Failed to run sudo rm: {e}")),
+				})?;
+			if !status.success() {
+				return Err(AppError::RunnerError(format!(
+					"sudo rm {} exited with {status}",
+					current_exe.display()
+				)));
+			}
+		}
+		Err(err) => {
+			return Err(AppError::RunnerError(format!(
+				"Failed to delete running binary: {err}"
+			)));
+		}
+	}
+
+	CommandOutput::builder()
+		.text("Patr CLI uninstalled.".to_string())
+		.json(ApiSuccessResponseBody::empty().to_json_value())
+		.build()
+		.into_result()
+}

--- a/cli/src/commands/upgrade.rs
+++ b/cli/src/commands/upgrade.rs
@@ -24,7 +24,8 @@ pub struct Args {
 	#[arg(long)]
 	pub force: bool,
 	/// Print what an upgrade would do and exit without modifying anything.
-	/// Exit codes: 0 = up to date, 1 = update available, 2 = error.
+	/// Exits 0 on success (whether up-to-date or an update is available); exits
+	/// 1 only on error. Parse the text/JSON output to distinguish the two.
 	#[arg(long)]
 	pub check: bool,
 }

--- a/cli/src/commands/upgrade.rs
+++ b/cli/src/commands/upgrade.rs
@@ -1,0 +1,455 @@
+use std::{
+	io::Read as _,
+	path::{Path, PathBuf},
+	process::Command,
+};
+
+use clap::Args as ClapArgs;
+use models::ApiSuccessResponseBody;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::prelude::*;
+
+/// Args for `patr upgrade`.
+#[derive(Debug, Clone, ClapArgs)]
+pub struct Args {
+	/// Switch the target channel. Persisted to your preferences — future
+	/// `patr upgrade` runs use this channel until you change it again.
+	#[arg(long = "channel", value_enum)]
+	pub channel: Option<Channel>,
+	/// Skip the "already up to date" short-circuit. Does not permit downgrades
+	/// across channels — run `patr uninstall` and reinstall to go back.
+	#[arg(long)]
+	pub force: bool,
+	/// Print what an upgrade would do and exit without modifying anything.
+	/// Exit codes: 0 = up to date, 1 = update available, 2 = error.
+	#[arg(long)]
+	pub check: bool,
+}
+
+/// Minimal subset of the GitHub Releases API response we care about.
+#[derive(Debug, Deserialize)]
+struct GhRelease {
+	/// Release tag (e.g. `v0.18.0`, `alpha`).
+	tag_name: String,
+	/// Files uploaded to the release.
+	assets: Vec<GhAsset>,
+}
+
+/// A single release asset returned by the GitHub Releases API.
+#[derive(Debug, Deserialize)]
+struct GhAsset {
+	/// Filename of the asset.
+	name: String,
+	/// Browser-facing download URL.
+	browser_download_url: String,
+}
+
+/// Machine-readable output of `patr upgrade`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpgradeOutput {
+	/// The channel the upgrade is tracking.
+	channel: Channel,
+	/// The version this binary is running.
+	current: String,
+	/// The version the target channel is currently at.
+	remote: String,
+	/// What happened: `upToDate`, `install`, `reinstall`, `installed`.
+	action: &'static str,
+}
+
+/// Decision made by comparing the current version to the target channel's
+/// remote version.
+#[derive(Debug, PartialEq, Eq)]
+enum Action {
+	/// No upgrade needed — local is as new or newer than remote.
+	UpToDate,
+	/// Remote is strictly newer — install it.
+	Install,
+	/// Same version as remote but user passed `--force` — reinstall.
+	Reinstall,
+}
+
+impl Action {
+	/// Machine-readable tag for the JSON output.
+	fn as_str(&self) -> &'static str {
+		match self {
+			Self::UpToDate => "upToDate",
+			Self::Install => "install",
+			Self::Reinstall => "reinstall",
+		}
+	}
+}
+
+/// Upgrade the Patr CLI in place.
+pub async fn execute(
+	args: Args,
+	_global_args: GlobalArgs,
+	mut state: AppState,
+) -> Result<CommandOutput, AppError> {
+	if cfg!(feature = "package-managed") {
+		eprintln!("self-update is disabled for this build of patr");
+		eprintln!("this CLI is managed by your package manager — use it to upgrade");
+		return CommandOutput::builder()
+			.text(String::new())
+			.json(ApiSuccessResponseBody::empty().to_json_value())
+			.build()
+			.into_result();
+	}
+
+	if let Some(requested) = args.channel {
+		state.target_channel = requested;
+		state.clone().save()?;
+	}
+	let target = state.target_channel;
+
+	let current =
+		Version::parse(constants::PATR_BUILD_VERSION.trim_start_matches('v')).map_err(|e| {
+			AppError::RunnerError(format!(
+				"Failed to parse current version `{}`: {e}",
+				constants::PATR_BUILD_VERSION
+			))
+		})?;
+
+	let client = reqwest::Client::builder()
+		.user_agent(constants::USER_AGENT.as_str())
+		.build()
+		.map_err(|e| AppError::RunnerError(format!("Failed to build HTTP client: {e}")))?;
+
+	// Resolve the release for the target channel.
+	let api = format!(
+		"https://api.github.com/repos/{}/releases",
+		constants::GITHUB_REPO
+	);
+	let release = match target {
+		Channel::Beta => find_latest_beta(&client, &api).await?,
+		Channel::Stable | Channel::Alpha => {
+			let url = if target == Channel::Stable {
+				format!("{api}/latest")
+			} else {
+				format!("{api}/tags/alpha")
+			};
+			client
+				.get(&url)
+				.send()
+				.await
+				.and_then(|r| r.error_for_status())
+				.map_err(|e| AppError::RunnerError(format!("Failed to GET {url}: {e}")))?
+				.json::<GhRelease>()
+				.await
+				.map_err(|e| {
+					AppError::RunnerError(format!("Failed to decode response from {url}: {e}"))
+				})?
+		}
+	};
+
+	// Read the release's version.txt asset to learn the remote version.
+	let version_asset = release
+		.assets
+		.iter()
+		.find(|a| a.name == "version.txt")
+		.ok_or_else(|| {
+			AppError::RunnerError(format!(
+				"release {} is missing the `version.txt` asset",
+				release.tag_name
+			))
+		})?;
+	let remote_version_string = client
+		.get(&version_asset.browser_download_url)
+		.send()
+		.await
+		.and_then(|r| r.error_for_status())
+		.map_err(|e| AppError::RunnerError(format!("Failed to fetch version.txt: {e}")))?
+		.text()
+		.await
+		.map_err(|e| AppError::RunnerError(format!("Failed to read version.txt: {e}")))?
+		.trim()
+		.to_string();
+	let remote = Version::parse(remote_version_string.trim_start_matches('v')).map_err(|e| {
+		AppError::RunnerError(format!(
+			"Failed to parse remote version `{remote_version_string}`: {e}"
+		))
+	})?;
+
+	let action = {
+		use std::cmp::Ordering::*;
+		match remote.cmp(&current) {
+			Greater => Action::Install,
+			Equal if args.force => Action::Reinstall,
+			Equal => Action::UpToDate,
+			Less if args.force => {
+				return Err(AppError::RunnerError(format!(
+					"downgrade not supported.\n\
+					 You're on {current}; the target channel is at {remote}.\n\n\
+					 Options:\n\
+					 \u{20}\u{20}- Drop `--force` to set this as your target channel. You'll be upgraded\n\
+					 \u{20}\u{20}\u{20}\u{20}automatically once this channel reaches a version ahead of {current}.\n\
+					 \u{20}\u{20}- To downgrade right now: `patr uninstall` then reinstall.",
+				)));
+			}
+			Less => Action::UpToDate,
+		}
+	};
+
+	if args.check || action == Action::UpToDate {
+		let text = match action {
+			Action::UpToDate => {
+				format!("up to date (current: {current} on channel {target}; remote: {remote})")
+			}
+			Action::Install => format!("update available: {current} → {remote} (channel {target})"),
+			Action::Reinstall => format!("reinstall available: {current} (channel {target})"),
+		};
+		eprintln!("{text}");
+		// `--check` is expected to exit non-zero when an update is available so
+		// callers can script against it. The current CommandOutput contract
+		// only gives us Ok→0 / Err→1, so "update available" under --check
+		// maps to exit 0 with a message — good enough for humans, not yet
+		// right for scripts. TODO: add an exit-code hint to AppError.
+		return CommandOutput::builder()
+			.text(text)
+			.json(
+				UpgradeOutput {
+					channel: target,
+					current: current.to_string(),
+					remote: remote.to_string(),
+					action: action.as_str(),
+				}
+				.to_json_value(),
+			)
+			.build()
+			.into_result();
+	}
+
+	// Locate the archive asset for this platform.
+	let platform = match (std::env::consts::OS, std::env::consts::ARCH) {
+		("linux", "x86_64") => "linux-amd64",
+		("linux", "aarch64") => "linux-arm64",
+		("macos", "aarch64") => "darwin-arm64",
+		(os, arch) => {
+			return Err(AppError::RunnerError(format!(
+				"unsupported platform: {os}/{arch}"
+			)));
+		}
+	};
+	let ext = if cfg!(target_os = "macos") {
+		"zip"
+	} else {
+		"tar.gz"
+	};
+	let expected_asset = format!("patr-{platform}.{ext}");
+	let artifact = release
+		.assets
+		.iter()
+		.find(|a| a.name == expected_asset)
+		.ok_or_else(|| {
+			AppError::RunnerError(format!(
+				"release {} is missing the expected asset `{expected_asset}`",
+				release.tag_name
+			))
+		})?;
+	let sha_asset_name = format!("{}.sha256sum", artifact.name);
+	let sha_asset = release
+		.assets
+		.iter()
+		.find(|a| a.name == sha_asset_name)
+		.ok_or_else(|| {
+			AppError::RunnerError(format!(
+				"release {} is missing {sha_asset_name}",
+				release.tag_name
+			))
+		})?;
+
+	let tmpdir = tempfile::TempDir::new()
+		.map_err(|e| AppError::RunnerError(format!("Failed to create temp dir: {e}")))?;
+	let archive_path = tmpdir.path().join(&artifact.name);
+	let sha_path = tmpdir.path().join(&sha_asset.name);
+
+	eprintln!("Downloading {}...", artifact.name);
+	download(&client, &artifact.browser_download_url, &archive_path).await?;
+	download(&client, &sha_asset.browser_download_url, &sha_path).await?;
+
+	eprint!("Verifying checksum... ");
+	{
+		let sha_contents = std::fs::read_to_string(&sha_path)
+			.map_err(|e| AppError::RunnerError(format!("Failed to read checksum file: {e}")))?;
+		let expected = sha_contents
+			.split_whitespace()
+			.next()
+			.ok_or_else(|| AppError::RunnerError("checksum file is empty".into()))?;
+
+		let mut file = std::fs::File::open(&archive_path)
+			.map_err(|e| AppError::RunnerError(format!("Failed to open archive: {e}")))?;
+		let mut hasher = Sha256::new();
+		let mut buf = [0u8; 8192];
+		loop {
+			let n = file
+				.read(&mut buf)
+				.map_err(|e| AppError::RunnerError(format!("Failed to read archive: {e}")))?;
+			if n == 0 {
+				break;
+			}
+			hasher.update(&buf[..n]);
+		}
+		let actual = hasher
+			.finalize()
+			.iter()
+			.map(|b| format!("{b:02x}"))
+			.collect::<String>();
+
+		if !expected.eq_ignore_ascii_case(&actual) {
+			return Err(AppError::RunnerError(format!(
+				"checksum mismatch for {}: expected {expected}, got {actual}",
+				artifact.name
+			)));
+		}
+	}
+	eprintln!("ok");
+
+	let new_binary = extract_binary(&archive_path, tmpdir.path())?;
+
+	let current_exe = std::env::current_exe().map_err(|e| {
+		AppError::RunnerError(format!("Failed to determine current binary path: {e}"))
+	})?;
+
+	swap_binary(&new_binary, &current_exe)?;
+
+	eprintln!("Updated: {current} → {remote}");
+
+	CommandOutput::builder()
+		.text(format!("Updated: {current} → {remote}"))
+		.json(
+			UpgradeOutput {
+				channel: target,
+				current: current.to_string(),
+				remote: remote.to_string(),
+				action: "installed",
+			}
+			.to_json_value(),
+		)
+		.build()
+		.into_result()
+}
+
+/// Paginate the GitHub releases list until we find the newest release whose
+/// tag matches `v*-beta.*`.
+async fn find_latest_beta(client: &reqwest::Client, api: &str) -> Result<GhRelease, AppError> {
+	let mut page: u32 = 1;
+	loop {
+		let url = format!("{api}?per_page=100&page={page}");
+		let releases = client
+			.get(&url)
+			.send()
+			.await
+			.and_then(|r| r.error_for_status())
+			.map_err(|e| AppError::RunnerError(format!("Failed to GET {url}: {e}")))?
+			.json::<Vec<GhRelease>>()
+			.await
+			.map_err(|e| {
+				AppError::RunnerError(format!("Failed to decode response from {url}: {e}"))
+			})?;
+		let len = releases.len();
+		if let Some(r) = releases
+			.into_iter()
+			.find(|r| r.tag_name.starts_with('v') && r.tag_name.contains("-beta."))
+		{
+			return Ok(r);
+		}
+		if len < 100 {
+			return Err(AppError::RunnerError(format!(
+				"no beta release found on {}",
+				constants::GITHUB_REPO
+			)));
+		}
+		page += 1;
+	}
+}
+
+/// Download `url` to `dest` in one shot, using the shared client.
+async fn download(client: &reqwest::Client, url: &str, dest: &Path) -> Result<(), AppError> {
+	let bytes = client
+		.get(url)
+		.send()
+		.await
+		.and_then(|r| r.error_for_status())
+		.map_err(|e| AppError::RunnerError(format!("Failed to download {url}: {e}")))?
+		.bytes()
+		.await
+		.map_err(|e| AppError::RunnerError(format!("Failed to read body of {url}: {e}")))?;
+
+	std::fs::write(dest, &bytes)
+		.map_err(|e| AppError::RunnerError(format!("Failed to write {}: {e}", dest.display())))
+}
+
+/// Extract the archive and return the path to the extracted `patr` binary.
+fn extract_binary(archive: &Path, into: &Path) -> Result<PathBuf, AppError> {
+	let archive_name = archive
+		.file_name()
+		.and_then(|s| s.to_str())
+		.ok_or_else(|| AppError::RunnerError("archive path is not utf-8".into()))?;
+
+	let file = std::fs::File::open(archive)
+		.map_err(|e| AppError::RunnerError(format!("Failed to open archive: {e}")))?;
+
+	if archive_name.ends_with(".tar.gz") {
+		tar::Archive::new(flate2::read::GzDecoder::new(file))
+			.unpack(into)
+			.map_err(|e| AppError::RunnerError(format!("Failed to extract tarball: {e}")))?;
+	} else if archive_name.ends_with(".zip") {
+		zip::ZipArchive::new(file)
+			.map_err(|e| AppError::RunnerError(format!("Failed to read zip: {e}")))?
+			.extract(into)
+			.map_err(|e| AppError::RunnerError(format!("Failed to extract zip: {e}")))?;
+	} else {
+		return Err(AppError::RunnerError(format!(
+			"unsupported archive extension: {archive_name}"
+		)));
+	}
+
+	let binary = into.join("patr");
+	if !binary.exists() {
+		return Err(AppError::RunnerError(
+			"downloaded archive did not contain an expected `patr` binary".into(),
+		));
+	}
+	Ok(binary)
+}
+
+/// Replace the running binary with `new_binary`. Falls back to `sudo install`
+/// when the current path isn't user-writable (typical for `/usr/local/bin`).
+fn swap_binary(new_binary: &Path, current_exe: &Path) -> Result<(), AppError> {
+	match self_replace::self_replace(new_binary) {
+		Ok(()) => return Ok(()),
+		Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {}
+		Err(err) => {
+			return Err(AppError::RunnerError(format!(
+				"Failed to replace running binary: {err}"
+			)));
+		}
+	}
+
+	eprintln!(
+		"Installing to {} (may prompt for your password).",
+		current_exe.display()
+	);
+	let status = Command::new("sudo")
+		.arg("install")
+		.args(["-m", "0755"])
+		.arg(new_binary)
+		.arg(current_exe)
+		.status()
+		.map_err(|e| match e.kind() {
+			std::io::ErrorKind::NotFound => AppError::RunnerError(
+				"sudo not found on PATH. Install sudo or run `patr upgrade` as root.".into(),
+			),
+			_ => AppError::RunnerError(format!("Failed to run sudo: {e}")),
+		})?;
+	if !status.success() {
+		return Err(AppError::RunnerError(format!(
+			"`sudo install` failed with exit status {status}"
+		)));
+	}
+	Ok(())
+}

--- a/cli/src/commands/upgrade.rs
+++ b/cli/src/commands/upgrade.rs
@@ -203,7 +203,6 @@ pub async fn execute(
 			Action::Install => format!("update available: {current} → {remote} (channel {target})"),
 			Action::Reinstall => format!("reinstall available: {current} (channel {target})"),
 		};
-		eprintln!("{text}");
 		// `--check` is expected to exit non-zero when an update is available so
 		// callers can script against it. The current CommandOutput contract
 		// only gives us Ok→0 / Err→1, so "update available" under --check
@@ -316,8 +315,6 @@ pub async fn execute(
 	})?;
 
 	swap_binary(&new_binary, &current_exe)?;
-
-	eprintln!("Updated: {current} → {remote}");
 
 	CommandOutput::builder()
 		.text(format!("Updated: {current} → {remote}"))

--- a/cli/src/commands/workspaced/container_registry/build.rs
+++ b/cli/src/commands/workspaced/container_registry/build.rs
@@ -46,10 +46,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state.clone()
+	} = state.auth.clone()
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/container_registry/create.rs
+++ b/cli/src/commands/workspaced/container_registry/create.rs
@@ -18,10 +18,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/container_registry/delete.rs
+++ b/cli/src/commands/workspaced/container_registry/delete.rs
@@ -18,10 +18,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/container_registry/image/delete.rs
+++ b/cli/src/commands/workspaced/container_registry/image/delete.rs
@@ -21,10 +21,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/container_registry/image/list.rs
+++ b/cli/src/commands/workspaced/container_registry/image/list.rs
@@ -19,10 +19,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/container_registry/image/list.rs
+++ b/cli/src/commands/workspaced/container_registry/image/list.rs
@@ -176,6 +176,7 @@ pub(super) async fn execute(
 		.into_result()
 }
 
+/// Format a byte count as a human-readable string (GB / MB / KB / B).
 fn format_size(bytes: u64) -> String {
 	const KB: u64 = 1024;
 	const MB: u64 = KB * 1024;

--- a/cli/src/commands/workspaced/container_registry/list.rs
+++ b/cli/src/commands/workspaced/container_registry/list.rs
@@ -107,6 +107,7 @@ pub(super) async fn execute(
 		.into_result()
 }
 
+/// Format a byte count as a human-readable string (GiB / MiB / KiB / B).
 fn format_size(bytes: u64) -> String {
 	const KIB: u64 = 1024;
 	const MIB: u64 = KIB * 1024;

--- a/cli/src/commands/workspaced/container_registry/list.rs
+++ b/cli/src/commands/workspaced/container_registry/list.rs
@@ -9,10 +9,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/container_registry/login.rs
+++ b/cli/src/commands/workspaced/container_registry/login.rs
@@ -37,12 +37,19 @@ pub(super) async fn execute(
 			_ => AppError::RunnerError(format!("Failed to run `docker login`: {e}")),
 		})?;
 
-	child
-		.stdin
-		.as_mut()
-		.expect("stdin was piped")
-		.write_all(token.0.token().as_bytes())
-		.map_err(|e| AppError::RunnerError(format!("Failed to pipe token to docker login: {e}")))?;
+	{
+		let mut stdin = child.stdin.take().ok_or_else(|| {
+			AppError::RunnerError("`docker login` did not expose a stdin handle".to_string())
+		})?;
+		stdin
+			.write_all(token.0.token().as_bytes())
+			.and_then(|()| stdin.write_all(b"\n"))
+			.map_err(|e| {
+				AppError::RunnerError(format!("Failed to pipe token to docker login: {e}"))
+			})?;
+		// Dropping the handle here closes the pipe so docker sees EOF on stdin
+		// and exits; otherwise `wait()` can hang.
+	}
 
 	let status = child
 		.wait()

--- a/cli/src/commands/workspaced/container_registry/login.rs
+++ b/cli/src/commands/workspaced/container_registry/login.rs
@@ -14,7 +14,7 @@ pub(super) async fn execute(
 	_global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn { token, .. } = state else {
+	let AuthState::LoggedIn { token, .. } = state.auth else {
 		return Err(AppError::NotLoggedIn);
 	};
 

--- a/cli/src/commands/workspaced/container_registry/push.rs
+++ b/cli/src/commands/workspaced/container_registry/push.rs
@@ -124,13 +124,17 @@ pub(super) async fn execute(
 				.unwrap_or_else(|| panic!("No repository found with name: `{selected}`"))
 		});
 
+	// Digest refs (`image@sha256:…`) look like they have a tag after the last
+	// `:`, but that `:` belongs to the digest — don't infer a tag from it.
+	let inferred_tag = (!args.source.contains('@'))
+		.then(|| args.source.rsplit_once(':'))
+		.flatten()
+		.and_then(|(_, rest)| (!rest.is_empty() && !rest.contains('/')).then(|| rest.to_string()));
+
 	let tag = if let Some(tag) = args.tag {
 		tag
-	} else if let Some((_, rest)) = args.source.rsplit_once(':') &&
-		!rest.is_empty() &&
-		!rest.contains('/')
-	{
-		rest.to_string()
+	} else if let Some(inferred) = inferred_tag {
+		inferred
 	} else if std::io::stdin().is_terminal() {
 		let accept_latest = Confirm::new("No tag specified. Use 'latest'?")
 			.with_default(true)

--- a/cli/src/commands/workspaced/container_registry/push.rs
+++ b/cli/src/commands/workspaced/container_registry/push.rs
@@ -29,10 +29,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state.clone()
+	} = state.auth.clone()
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/container_registry/tags.rs
+++ b/cli/src/commands/workspaced/container_registry/tags.rs
@@ -19,10 +19,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/container_registry/url.rs
+++ b/cli/src/commands/workspaced/container_registry/url.rs
@@ -19,10 +19,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/deployment/create.rs
+++ b/cli/src/commands/workspaced/deployment/create.rs
@@ -577,10 +577,10 @@ pub async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/deployment/create.rs
+++ b/cli/src/commands/workspaced/deployment/create.rs
@@ -9,6 +9,8 @@ use models::api::{
 
 use crate::{prelude::*, utils::StringExt};
 
+/// Args for `patr deployment create`. Any field left as `None` is prompted
+/// for interactively (or required in non-TTY mode).
 #[derive(Debug, Clone, ClapArgs)]
 pub struct Args {
 	/// The name of the deployment
@@ -114,24 +116,42 @@ pub struct Args {
 	pub deploy_on_create: Option<bool>,
 }
 
+/// A field in the interactive "edit before create" menu. Each variant maps to
+/// one row the user can pick to edit (plus the terminal `CreateDeployment`
+/// row that submits the request).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MenuField {
+	/// Edit the deployment name.
 	Name,
+	/// Edit the source registry + image.
 	Registry,
+	/// Edit the image tag.
 	ImageTag,
+	/// Pick the runner this deployment will run on.
 	Runner,
+	/// Pick the machine type (CPU / memory).
 	MachineType,
+	/// Toggle auto-deploy on image push.
 	DeployOnPush,
+	/// Edit the minimum horizontal scale.
 	MinScale,
+	/// Edit the maximum horizontal scale.
 	MaxScale,
+	/// Edit the exposed ports.
 	Ports,
+	/// Edit the environment variables.
 	EnvVars,
+	/// Toggle whether to deploy immediately after create.
 	DeployOnCreate,
+	/// Submit the request and create the deployment.
 	CreateDeployment,
 }
 
+/// One row in the interactive menu — pairs a field with its rendered label.
 struct MenuItem {
+	/// Which field this row edits.
 	field: MenuField,
+	/// Rendered label shown to the user (includes the current value).
 	display: String,
 }
 
@@ -141,6 +161,8 @@ impl fmt::Display for MenuItem {
 	}
 }
 
+/// Render the current deployment-in-progress as a list of menu rows for the
+/// interactive picker.
 fn build_menu_items(
 	name: &Option<String>,
 	registry: &Option<DeploymentRegistry>,
@@ -272,6 +294,8 @@ fn build_menu_items(
 	]
 }
 
+/// Parse `PORT:TYPE` strings (e.g. `8080:http`) passed via `--port` into the
+/// API's port-map format.
 fn parse_ports_from_args(
 	ports: Vec<String>,
 ) -> Result<BTreeMap<StringifiedU16, ExposedPortType>, AppError> {
@@ -309,6 +333,7 @@ fn parse_ports_from_args(
 		.collect()
 }
 
+/// Parse `KEY=VALUE` strings passed via `--env` into the API's env-var map.
 fn parse_env_vars_from_args(
 	env_vars: Vec<String>,
 ) -> Result<BTreeMap<String, EnvironmentVariableValue>, AppError> {
@@ -337,6 +362,8 @@ fn parse_env_vars_from_args(
 		.collect()
 }
 
+/// Search runners in the workspace by name prefix. Used as the search
+/// backend for the interactive runner picker.
 async fn search_runners(
 	workspace_id: Uuid,
 	token: &BearerToken,
@@ -372,6 +399,9 @@ async fn search_runners(
 	.runners)
 }
 
+/// Search Patr container repositories by name prefix. Used as the search
+/// backend for the interactive repository picker when the registry is
+/// `registry.patr.cloud`.
 async fn search_repositories(
 	workspace_id: Uuid,
 	token: &BearerToken,
@@ -407,6 +437,8 @@ async fn search_repositories(
 	.repositories)
 }
 
+/// Interactive editor for the source registry + image — picks either a
+/// Patr-managed repository or an external registry/image name.
 async fn edit_registry(
 	workspace_id: Uuid,
 	token: &BearerToken,
@@ -467,6 +499,8 @@ async fn edit_registry(
 	Ok(())
 }
 
+/// Interactive editor for the exposed-ports map: loops through add/remove
+/// actions until the user selects Done.
 fn edit_ports(ports: &mut BTreeMap<StringifiedU16, ExposedPortType>) {
 	loop {
 		let mut choices = vec!["Add port".to_string()];
@@ -529,6 +563,8 @@ fn edit_ports(ports: &mut BTreeMap<StringifiedU16, ExposedPortType>) {
 	}
 }
 
+/// Interactive editor for the environment-variables map: loops through
+/// add/remove actions until the user selects Done.
 fn edit_env_vars(env_vars: &mut BTreeMap<String, EnvironmentVariableValue>) {
 	loop {
 		let mut choices = vec!["Add variable".to_string()];
@@ -572,6 +608,9 @@ fn edit_env_vars(env_vars: &mut BTreeMap<String, EnvironmentVariableValue>) {
 	}
 }
 
+/// Create a deployment. Fields missing from `args` are prompted for
+/// interactively via the edit-before-create menu; in non-TTY mode all
+/// required fields must be passed as flags.
 pub async fn execute(
 	args: Args,
 	global_args: GlobalArgs,

--- a/cli/src/commands/workspaced/deployment/delete.rs
+++ b/cli/src/commands/workspaced/deployment/delete.rs
@@ -21,10 +21,10 @@ pub async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/deployment/delete.rs
+++ b/cli/src/commands/workspaced/deployment/delete.rs
@@ -4,6 +4,7 @@ use models::api::{user::*, workspace::deployment::*};
 
 use crate::prelude::*;
 
+/// Args for `patr deployment delete`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct Args {
 	/// The name of the deployment
@@ -16,6 +17,7 @@ pub struct Args {
 	pub name: Option<String>,
 }
 
+/// Delete a deployment (by name/id, or picked interactively).
 pub async fn execute(
 	args: Args,
 	global_args: GlobalArgs,

--- a/cli/src/commands/workspaced/deployment/list.rs
+++ b/cli/src/commands/workspaced/deployment/list.rs
@@ -14,10 +14,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/deployment/list.rs
+++ b/cli/src/commands/workspaced/deployment/list.rs
@@ -123,7 +123,10 @@ pub(super) async fn execute(
 				.repository
 				.name;
 
-				format!("registry.patr.cloud/{}:{}", repo_name, deployment.image_tag)
+				format!(
+					"registry.patr.cloud/{}/{}:{}",
+					workspace_id, repo_name, deployment.image_tag
+				)
 			}
 			DeploymentRegistry::ExternalRegistry {
 				registry,

--- a/cli/src/commands/workspaced/deployment/mod.rs
+++ b/cli/src/commands/workspaced/deployment/mod.rs
@@ -46,6 +46,7 @@ pub enum DeploymentActionCommand {
 	Delete(delete::Args),
 }
 
+/// Dispatch a deployment subcommand to its handler.
 pub async fn execute(
 	command: DeploymentCommand,
 	global_args: GlobalArgs,

--- a/cli/src/commands/workspaced/deployment/start.rs
+++ b/cli/src/commands/workspaced/deployment/start.rs
@@ -24,10 +24,10 @@ pub async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/deployment/start.rs
+++ b/cli/src/commands/workspaced/deployment/start.rs
@@ -4,6 +4,7 @@ use models::api::{user::*, workspace::deployment::*};
 
 use crate::prelude::*;
 
+/// Args for `patr deployment start`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct Args {
 	/// The name of the deployment
@@ -19,6 +20,7 @@ pub struct Args {
 	pub force_restart: bool,
 }
 
+/// Start a deployment (by name/id, or picked interactively).
 pub async fn execute(
 	args: Args,
 	global_args: GlobalArgs,

--- a/cli/src/commands/workspaced/deployment/stop.rs
+++ b/cli/src/commands/workspaced/deployment/stop.rs
@@ -21,10 +21,10 @@ pub async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/deployment/stop.rs
+++ b/cli/src/commands/workspaced/deployment/stop.rs
@@ -4,6 +4,7 @@ use models::api::{user::*, workspace::deployment::*};
 
 use crate::prelude::*;
 
+/// Args for `patr deployment stop`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct Args {
 	/// The name of the deployment
@@ -16,6 +17,7 @@ pub struct Args {
 	pub name: Option<String>,
 }
 
+/// Stop a running deployment (by name/id, or picked interactively).
 pub async fn execute(
 	args: Args,
 	global_args: GlobalArgs,

--- a/cli/src/commands/workspaced/runner/create.rs
+++ b/cli/src/commands/workspaced/runner/create.rs
@@ -18,10 +18,10 @@ pub async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/runner/current.rs
+++ b/cli/src/commands/workspaced/runner/current.rs
@@ -9,12 +9,16 @@ use serde::Serialize;
 
 use crate::prelude::*;
 
+/// JSON output shape for a self-hosted runner (mode = `selfHosted`).
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SelfHostedOutput {
+	/// Path to the config file on disk.
 	config: String,
+	/// Runner kind (`docker`, `kubernetes`).
 	#[serde(rename = "type")]
 	runner_type: String,
+	/// Always `"selfHosted"` for this variant.
 	mode: &'static str,
 }
 

--- a/cli/src/commands/workspaced/runner/current.rs
+++ b/cli/src/commands/workspaced/runner/current.rs
@@ -5,8 +5,18 @@ use comfy_table::Table;
 use common::prelude::{RunnerMode, RunnerSettings};
 use docker::prelude::DockerSettings;
 use models::api::workspace::runner::*;
+use serde::Serialize;
 
 use crate::prelude::*;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SelfHostedOutput {
+	config: String,
+	#[serde(rename = "type")]
+	runner_type: String,
+	mode: &'static str,
+}
 
 /// The arguments for the `runner current` command.
 #[derive(Debug, Clone, ClapArgs)]
@@ -56,11 +66,14 @@ pub(super) async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 			table.add_row(["Mode".to_string(), "Self-hosted".to_string()]);
 			CommandOutput::builder()
 				.text(table.to_string())
-				.json(serde_json::json!({
-					"config": config_path.display().to_string(),
-					"type": runner_type_str,
-					"mode": "selfHosted",
-				}))
+				.json(
+					SelfHostedOutput {
+						config: config_path.display().to_string(),
+						runner_type: runner_type_str.to_string(),
+						mode: "selfHosted",
+					}
+					.to_json_value(),
+				)
 				.build()
 				.into_result()
 		}

--- a/cli/src/commands/workspaced/runner/deployments.rs
+++ b/cli/src/commands/workspaced/runner/deployments.rs
@@ -211,7 +211,10 @@ pub(super) async fn execute(
 				.repository
 				.name;
 
-				format!("registry.patr.cloud/{}:{}", repo_name, deployment.image_tag)
+				format!(
+					"registry.patr.cloud/{}/{}:{}",
+					workspace_id, repo_name, deployment.image_tag
+				)
 			}
 			DeploymentRegistry::ExternalRegistry {
 				registry,

--- a/cli/src/commands/workspaced/runner/deployments.rs
+++ b/cli/src/commands/workspaced/runner/deployments.rs
@@ -38,10 +38,10 @@ pub(super) async fn execute(
 	// - When `--runner` is given, use the CLI's session token + workspace.
 	// - Otherwise read the local runner config and use the runner's own api token.
 	let (workspace_id, runner_id, token) = if let Some(runner_ref) = args.runner {
-		let AppState::LoggedIn {
+		let AuthState::LoggedIn {
 			token,
 			current_workspace,
-		} = state
+		} = state.auth
 		else {
 			return Err(AppError::NotLoggedIn);
 		};

--- a/cli/src/commands/workspaced/runner/list.rs
+++ b/cli/src/commands/workspaced/runner/list.rs
@@ -9,10 +9,10 @@ pub(super) async fn execute(
 	global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/runner/mod.rs
+++ b/cli/src/commands/workspaced/runner/mod.rs
@@ -8,12 +8,12 @@ mod create;
 mod current;
 /// List deployments assigned to a specific runner
 mod deployments;
-/// Install a systemd service for the runner
-mod install_service;
 /// List all runners
 mod list;
 /// The command to run a configured runner
 mod run;
+/// Systemd service lifecycle for the runner (install / uninstall / status)
+mod service;
 /// The command to setup the CLI's configuration settings for first time use.
 mod setup;
 
@@ -44,11 +44,11 @@ pub enum RunnerActionCommand {
 	#[command(alias = "exec", alias = "execute", alias = "start")]
 	/// Run a configured runner
 	Run(run::Args),
-	#[command(alias = "install")]
-	/// Install a systemd service for the runner
-	InstallService(install_service::Args),
+	/// Systemd service lifecycle for the runner (install / uninstall / status)
+	#[command(subcommand)]
+	Service(service::ServiceCommand),
 	/// Print info about the runner configured on this host
-	#[command(alias = "whoami", alias = "info")]
+	#[command(alias = "whoami", alias = "info", alias = "status")]
 	Current(current::Args),
 	/// List deployments assigned to a runner
 	#[command(alias = "list-deployments", alias = "ls-deployments")]
@@ -71,7 +71,7 @@ pub async fn execute(
 			list::execute(global_args, state).await
 		}
 		RunnerCommand::RunnerAction(Run(args)) => run::execute(args).await,
-		RunnerCommand::RunnerAction(InstallService(args)) => install_service::execute(args).await,
+		RunnerCommand::RunnerAction(Service(cmd)) => service::execute(cmd).await,
 		RunnerCommand::RunnerAction(Current(args)) => current::execute(args).await,
 		RunnerCommand::RunnerAction(Deployments(args)) => {
 			deployments::execute(args, global_args, state).await

--- a/cli/src/commands/workspaced/runner/mod.rs
+++ b/cli/src/commands/workspaced/runner/mod.rs
@@ -71,7 +71,7 @@ pub async fn execute(
 			list::execute(global_args, state).await
 		}
 		RunnerCommand::RunnerAction(Run(args)) => run::execute(args).await,
-		RunnerCommand::RunnerAction(Service(cmd)) => service::execute(cmd).await,
+		RunnerCommand::RunnerAction(Service(cmd)) => service::execute(cmd, global_args).await,
 		RunnerCommand::RunnerAction(Current(args)) => current::execute(args).await,
 		RunnerCommand::RunnerAction(Deployments(args)) => {
 			deployments::execute(args, global_args, state).await

--- a/cli/src/commands/workspaced/runner/run.rs
+++ b/cli/src/commands/workspaced/runner/run.rs
@@ -18,6 +18,7 @@ pub struct Args {
 	pub config: Option<PathBuf>,
 }
 
+/// Run the configured runner in the foreground.
 pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 	match args.runner_type {
 		RunnerType::Kubernetes => {

--- a/cli/src/commands/workspaced/runner/service/install.rs
+++ b/cli/src/commands/workspaced/runner/service/install.rs
@@ -6,9 +6,10 @@ use std::{
 
 use clap::Args as ClapArgs;
 
+use super::{run_systemctl, sudo_spawn_error};
 use crate::prelude::*;
 
-/// The arguments for the `runner install-service` command.
+/// The arguments for the `runner service install` command.
 ///
 /// Run this command without sudo. Patr resolves your config and renders the
 /// systemd unit as your user, then uses `sudo` to write the unit file and run
@@ -24,6 +25,7 @@ pub struct Args {
 	pub config: Option<PathBuf>,
 }
 
+/// Install the runner as a systemd service.
 pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 	if !Path::new("/run/systemd/system").exists() {
 		return Err(AppError::RunnerError(
@@ -85,7 +87,7 @@ pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 	let service_file_path = format!("/etc/systemd/system/{service_name}");
 
 	let unit_file = format!(
-		include_str!("../../../../../assets/cli/systemd-service.template"),
+		include_str!("../../../../../../assets/cli/systemd-service.template"),
 		runner_type_str = runner_type_str,
 		username = username,
 		groupname = groupname,
@@ -170,42 +172,5 @@ pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 			.json(ApiSuccessResponseBody::empty().to_json_value())
 			.build()
 			.into_result()
-	}
-}
-
-/// Run `systemctl <args>` — directly when root, otherwise via `sudo`.
-fn run_systemctl(args: &[&str], is_root: bool) -> Result<(), AppError> {
-	let status = if is_root {
-		Command::new("systemctl")
-			.args(args)
-			.status()
-			.map_err(|e| AppError::RunnerError(format!("Failed to run systemctl: {e}")))?
-	} else {
-		let mut full_args = Vec::<&str>::with_capacity(args.len() + 1);
-		full_args.push("systemctl");
-		full_args.extend_from_slice(args);
-		Command::new("sudo")
-			.args(&full_args)
-			.status()
-			.map_err(|e| sudo_spawn_error(e, "sudo systemctl"))?
-	};
-
-	if !status.success() {
-		return Err(AppError::RunnerError(format!(
-			"systemctl {} failed (exit status {status})",
-			args.join(" ")
-		)));
-	}
-
-	Ok(())
-}
-
-fn sudo_spawn_error(e: std::io::Error, what: &str) -> AppError {
-	if e.kind() == std::io::ErrorKind::NotFound {
-		AppError::RunnerError(
-			"sudo not found on PATH. Install sudo or run this command as root.".to_string(),
-		)
-	} else {
-		AppError::RunnerError(format!("Failed to run {what}: {e}"))
 	}
 }

--- a/cli/src/commands/workspaced/runner/service/install.rs
+++ b/cli/src/commands/workspaced/runner/service/install.rs
@@ -56,6 +56,16 @@ pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 		.map_err(|e| AppError::RunnerError(format!("Failed to determine patr binary path: {e}")))?;
 
 	let uid = uzers::get_current_uid();
+	// Running under `sudo patr runner service install` would otherwise silently
+	// install a unit that runs as root. The command is designed to be invoked
+	// without sudo — it escalates only for the write + systemctl calls.
+	if uid == 0 && std::env::var_os("SUDO_UID").is_some() {
+		return Err(AppError::RunnerError(
+			"Don't invoke this command with sudo. Run `patr runner service install` as your \
+			 normal user — it will prompt for your password when needed."
+				.to_string(),
+		));
+	}
 	let user = uzers::get_user_by_uid(uid)
 		.ok_or_else(|| AppError::RunnerError(format!("Failed to resolve user for UID {uid}")))?;
 
@@ -123,14 +133,16 @@ pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 			.spawn()
 			.map_err(|e| sudo_spawn_error(e, "sudo tee"))?;
 
-		child
-			.stdin
-			.as_mut()
-			.expect("stdin was piped")
-			.write_all(unit_file.as_bytes())
-			.map_err(|e| {
+		{
+			let mut stdin = child.stdin.take().ok_or_else(|| {
+				AppError::RunnerError("`sudo tee` did not expose a stdin handle".to_string())
+			})?;
+			stdin.write_all(unit_file.as_bytes()).map_err(|e| {
 				AppError::RunnerError(format!("Failed to pipe unit file to sudo tee: {e}"))
 			})?;
+			// Dropping the handle here closes the pipe so `tee` sees EOF and
+			// exits; otherwise `wait()` can hang.
+		}
 
 		let status = child
 			.wait()

--- a/cli/src/commands/workspaced/runner/service/mod.rs
+++ b/cli/src/commands/workspaced/runner/service/mod.rs
@@ -1,0 +1,74 @@
+use std::process::Command;
+
+use clap::Subcommand;
+
+use crate::prelude::*;
+
+/// Install the runner as a systemd service
+mod install;
+/// Show `systemctl status` for the installed runner service
+mod status;
+/// Stop, disable, and remove the installed runner service
+mod uninstall;
+
+/// The commands that can be executed on the runner's systemd service
+#[derive(Debug, Clone, Subcommand)]
+#[command(rename_all = "kebab-case")]
+pub enum ServiceCommand {
+	/// Install the runner as a systemd service
+	Install(install::Args),
+	/// Stop, disable, and remove the installed runner service
+	#[command(alias = "remove", alias = "rm")]
+	Uninstall(uninstall::Args),
+	/// Show `systemctl status` for the installed runner service
+	#[command(alias = "info")]
+	Status(status::Args),
+}
+
+/// Dispatch a runner service subcommand
+pub async fn execute(command: ServiceCommand) -> Result<CommandOutput, AppError> {
+	match command {
+		ServiceCommand::Install(args) => install::execute(args).await,
+		ServiceCommand::Uninstall(args) => uninstall::execute(args).await,
+		ServiceCommand::Status(args) => status::execute(args).await,
+	}
+}
+
+/// Run `systemctl <args>` — directly when root, otherwise via `sudo`.
+pub(super) fn run_systemctl(args: &[&str], is_root: bool) -> Result<(), AppError> {
+	let status = if is_root {
+		Command::new("systemctl")
+			.args(args)
+			.status()
+			.map_err(|e| AppError::RunnerError(format!("Failed to run systemctl: {e}")))?
+	} else {
+		let mut full_args = Vec::<&str>::with_capacity(args.len() + 1);
+		full_args.push("systemctl");
+		full_args.extend_from_slice(args);
+		Command::new("sudo")
+			.args(&full_args)
+			.status()
+			.map_err(|e| sudo_spawn_error(e, "sudo systemctl"))?
+	};
+
+	if !status.success() {
+		return Err(AppError::RunnerError(format!(
+			"systemctl {} failed (exit status {status})",
+			args.join(" ")
+		)));
+	}
+
+	Ok(())
+}
+
+/// Convert an `io::Error` from spawning `sudo` into a user-friendly
+/// [`AppError::RunnerError`].
+pub(super) fn sudo_spawn_error(e: std::io::Error, what: &str) -> AppError {
+	if e.kind() == std::io::ErrorKind::NotFound {
+		AppError::RunnerError(
+			"sudo not found on PATH. Install sudo or run this command as root.".to_string(),
+		)
+	} else {
+		AppError::RunnerError(format!("Failed to run {what}: {e}"))
+	}
+}

--- a/cli/src/commands/workspaced/runner/service/mod.rs
+++ b/cli/src/commands/workspaced/runner/service/mod.rs
@@ -26,11 +26,14 @@ pub enum ServiceCommand {
 }
 
 /// Dispatch a runner service subcommand
-pub async fn execute(command: ServiceCommand) -> Result<CommandOutput, AppError> {
+pub async fn execute(
+	command: ServiceCommand,
+	global_args: GlobalArgs,
+) -> Result<CommandOutput, AppError> {
 	match command {
 		ServiceCommand::Install(args) => install::execute(args).await,
 		ServiceCommand::Uninstall(args) => uninstall::execute(args).await,
-		ServiceCommand::Status(args) => status::execute(args).await,
+		ServiceCommand::Status(args) => status::execute(args, global_args).await,
 	}
 }
 

--- a/cli/src/commands/workspaced/runner/service/status.rs
+++ b/cli/src/commands/workspaced/runner/service/status.rs
@@ -8,10 +8,14 @@ use serde::Serialize;
 
 use crate::prelude::*;
 
+/// JSON output shape for `patr runner service status`.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct StatusOutput {
+	/// Systemd unit name that was queried.
 	service: String,
+	/// Exit code from `systemctl status` (None if the process was terminated
+	/// by a signal).
 	exit_status: Option<i32>,
 }
 
@@ -24,7 +28,10 @@ pub struct Args {
 }
 
 /// Show `systemctl status` for the installed runner service.
-pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
+pub async fn execute(
+	args: Args,
+	global_args: GlobalArgs,
+) -> Result<CommandOutput, AppError> {
 	if !Path::new("/run/systemd/system").exists() {
 		return Err(AppError::RunnerError(
 			"systemd is not available on this system".to_string(),
@@ -37,10 +44,18 @@ pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 	};
 	let service_name = format!("patr-{runner_type_str}-runner.service");
 
+	// JSON modes would interleave systemctl's human-text output with the JSON
+	// payload on stdout and break machine parsing. Consumers get the exit code
+	// in the JSON body; re-run in text mode to see the diagnostic text.
+	let (stdout, stderr) = match global_args.output {
+		OutputType::Text => (Stdio::inherit(), Stdio::inherit()),
+		OutputType::Json | OutputType::PrettyJson => (Stdio::null(), Stdio::null()),
+	};
+
 	let status = Command::new("systemctl")
 		.args(["status", &service_name])
-		.stdout(Stdio::inherit())
-		.stderr(Stdio::inherit())
+		.stdout(stdout)
+		.stderr(stderr)
 		.status()
 		.map_err(|e| AppError::RunnerError(format!("Failed to run systemctl: {e}")))?;
 

--- a/cli/src/commands/workspaced/runner/service/status.rs
+++ b/cli/src/commands/workspaced/runner/service/status.rs
@@ -1,0 +1,58 @@
+use std::{
+	path::Path,
+	process::{Command, Stdio},
+};
+
+use clap::Args as ClapArgs;
+use serde::Serialize;
+
+use crate::prelude::*;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusOutput {
+	service: String,
+	exit_status: Option<i32>,
+}
+
+/// The arguments for the `runner service status` command.
+#[derive(Debug, Clone, ClapArgs)]
+pub struct Args {
+	/// The type of runner whose service status to show
+	#[arg(value_enum)]
+	pub runner_type: RunnerType,
+}
+
+/// Show `systemctl status` for the installed runner service.
+pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
+	if !Path::new("/run/systemd/system").exists() {
+		return Err(AppError::RunnerError(
+			"systemd is not available on this system".to_string(),
+		));
+	}
+
+	let runner_type_str = match args.runner_type {
+		RunnerType::Docker => "docker",
+		RunnerType::Kubernetes => "kubernetes",
+	};
+	let service_name = format!("patr-{runner_type_str}-runner.service");
+
+	let status = Command::new("systemctl")
+		.args(["status", &service_name])
+		.stdout(Stdio::inherit())
+		.stderr(Stdio::inherit())
+		.status()
+		.map_err(|e| AppError::RunnerError(format!("Failed to run systemctl: {e}")))?;
+
+	CommandOutput::builder()
+		.text(String::new())
+		.json(
+			StatusOutput {
+				service: service_name,
+				exit_status: status.code(),
+			}
+			.to_json_value(),
+		)
+		.build()
+		.into_result()
+}

--- a/cli/src/commands/workspaced/runner/service/uninstall.rs
+++ b/cli/src/commands/workspaced/runner/service/uninstall.rs
@@ -1,0 +1,94 @@
+use std::{io::IsTerminal, path::Path, process::Command};
+
+use clap::Args as ClapArgs;
+
+use super::{run_systemctl, sudo_spawn_error};
+use crate::prelude::*;
+
+/// The arguments for the `runner service uninstall` command.
+#[derive(Debug, Clone, ClapArgs)]
+pub struct Args {
+	/// The type of runner whose service to remove
+	#[arg(value_enum)]
+	pub runner_type: RunnerType,
+	/// Skip the confirmation prompt
+	#[arg(short = 'y', long = "yes")]
+	pub yes: bool,
+}
+
+/// Stop, disable, and remove the installed runner systemd service.
+pub async fn execute(args: Args) -> Result<CommandOutput, AppError> {
+	if !Path::new("/run/systemd/system").exists() {
+		return Err(AppError::RunnerError(
+			"systemd is not available on this system".to_string(),
+		));
+	}
+
+	let runner_type_str = match args.runner_type {
+		RunnerType::Docker => "docker",
+		RunnerType::Kubernetes => "kubernetes",
+	};
+	let service_name = format!("patr-{runner_type_str}-runner.service");
+	let service_file_path = format!("/etc/systemd/system/{service_name}");
+
+	let is_root = uzers::get_current_uid() == 0;
+
+	if !args.yes {
+		if !std::io::stdin().is_terminal() {
+			return Err(AppError::RunnerError(
+				"Running in non-TTY mode. Pass `-y` to confirm.".to_string(),
+			));
+		}
+		let confirmed =
+			inquire::Confirm::new(&format!("Stop, disable, and remove {service_name}?"))
+				.with_default(false)
+				.prompt()
+				.expect_tty("Failed to read uninstall confirmation");
+		if !confirmed {
+			return Err(AppError::RunnerError("Aborted.".to_string()));
+		}
+	}
+
+	if !is_root {
+		eprintln!(
+			"This will use sudo to run systemctl and remove {service_file_path}. You may be prompted for your password."
+		);
+	}
+
+	if let Err(err) = run_systemctl(&["stop", &service_name], is_root) {
+		eprintln!("systemctl stop: {err} (continuing)");
+	}
+	if let Err(err) = run_systemctl(&["disable", &service_name], is_root) {
+		eprintln!("systemctl disable: {err} (continuing)");
+	}
+
+	if is_root {
+		match std::fs::remove_file(&service_file_path) {
+			Ok(()) => {}
+			Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+			Err(e) => {
+				return Err(AppError::RunnerError(format!(
+					"Failed to remove {service_file_path}: {e}"
+				)));
+			}
+		}
+	} else {
+		let status = Command::new("sudo")
+			.args(["rm", "-f", &service_file_path])
+			.status()
+			.map_err(|e| sudo_spawn_error(e, "sudo rm"))?;
+		if !status.success() {
+			return Err(AppError::RunnerError(format!(
+				"Failed to remove {service_file_path} via sudo (exit status {status})"
+			)));
+		}
+	}
+
+	run_systemctl(&["daemon-reload"], is_root)?;
+
+	CommandOutput::builder()
+		.text(format!("Patr runner service `{service_name}` uninstalled."))
+		.json(ApiSuccessResponseBody::empty().to_json_value())
+		.build()
+		.into_result()
+}

--- a/cli/src/commands/workspaced/runner/setup.rs
+++ b/cli/src/commands/workspaced/runner/setup.rs
@@ -76,10 +76,10 @@ pub async fn execute(
 	let is_managed = mode_selection == MANAGED_OPTION;
 
 	let mode = if is_managed {
-		let AppState::LoggedIn {
+		let AuthState::LoggedIn {
 			token,
 			current_workspace,
-		} = state
+		} = state.auth
 		else {
 			return Err(AppError::NotLoggedIn);
 		};

--- a/cli/src/commands/workspaced/runner/setup.rs
+++ b/cli/src/commands/workspaced/runner/setup.rs
@@ -17,6 +17,7 @@ use rand::RngExt;
 
 use crate::prelude::*;
 
+/// Args for `patr runner setup`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct Args {
 	/// Force the setup even if the CLI is already configured
@@ -31,6 +32,8 @@ pub struct Args {
 	pub runner_type: RunnerType,
 }
 
+/// First-time configuration for a runner on this host — writes the runner
+/// config file used by `patr runner run` and `patr runner service install`.
 pub async fn execute(
 	args: Args,
 	_global_args: GlobalArgs,

--- a/cli/src/commands/workspaced/workspace/create.rs
+++ b/cli/src/commands/workspaced/workspace/create.rs
@@ -18,10 +18,10 @@ pub(super) async fn execute(
 	args: Args,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace: _,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/workspace/list.rs
+++ b/cli/src/commands/workspaced/workspace/list.rs
@@ -8,10 +8,10 @@ pub(super) async fn execute(
 	_global_args: GlobalArgs,
 	state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace: _,
-	} = state
+	} = state.auth
 	else {
 		return Err(AppError::NotLoggedIn);
 	};

--- a/cli/src/commands/workspaced/workspace/switch.rs
+++ b/cli/src/commands/workspaced/workspace/switch.rs
@@ -21,12 +21,12 @@ pub struct Args {
 pub(super) async fn execute(
 	_: GlobalArgs,
 	args: Args,
-	state: AppState,
+	mut state: AppState,
 ) -> Result<CommandOutput, AppError> {
-	let AppState::LoggedIn {
+	let AuthState::LoggedIn {
 		token,
 		current_workspace: _,
-	} = state
+	} = state.auth.clone()
 	else {
 		return Err(AppError::NotLoggedIn);
 	};
@@ -68,11 +68,11 @@ pub(super) async fn execute(
 				.clone()
 		});
 
-	AppState::LoggedIn {
+	state.auth = AuthState::LoggedIn {
 		token,
 		current_workspace: Some(workspace.id),
-	}
-	.save()?;
+	};
+	state.save()?;
 
 	CommandOutput {
 		text: format!("Switched to workspace `{}`", workspace.name),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,6 +22,8 @@ pub mod prelude {
 		error::AppError,
 		utils::{
 			AppState,
+			AuthState,
+			Channel,
 			IaacResolverExt,
 			RunnerType,
 			SearchAndSelect,

--- a/cli/src/utils/authenticator.rs
+++ b/cli/src/utils/authenticator.rs
@@ -21,11 +21,7 @@ impl WorkspacedArgs {
 		let token = if let Some(token) = &global_args.token {
 			BearerToken::from_str(token).map_err(|err| AppError::ParseError(err.to_string()))?
 		} else {
-			let AppState::LoggedIn {
-				token,
-				current_workspace: _,
-			} = state
-			else {
+			let AuthState::LoggedIn { token, .. } = &state.auth else {
 				return Err(AppError::NotLoggedIn);
 			};
 
@@ -37,10 +33,9 @@ impl WorkspacedArgs {
 				.parse::<Uuid>()
 				.map_err(|err| AppError::ParseError(err.to_string()))?
 		} else {
-			let AppState::LoggedIn {
-				token: _,
-				current_workspace,
-			} = state
+			let AuthState::LoggedIn {
+				current_workspace, ..
+			} = &state.auth
 			else {
 				return Err(AppError::NoWorkspace);
 			};

--- a/cli/src/utils/mod.rs
+++ b/cli/src/utils/mod.rs
@@ -14,7 +14,7 @@ mod storage;
 pub use self::{authenticator::*, client::*, ext_trait::*, search_and_select::*, storage::*};
 
 /// A list of all possible runner types that can be setup or run.
-#[derive(Debug, Copy, Clone, clap::ValueEnum)]
+#[derive(Debug, Copy, Clone, clap::ValueEnum, strum::EnumIter)]
 #[value(rename_all = "kebab-case")]
 pub enum RunnerType {
 	/// A runner that runs on a local machine and uses Docker to run the
@@ -52,6 +52,16 @@ pub mod constants {
 		".",
 		env!("CARGO_PKG_VERSION_PATCH"),
 	));
+
+	/// The full semver string CI baked into this binary. For dev builds this
+	/// falls back to `CARGO_PKG_VERSION`.
+	pub const PATR_BUILD_VERSION: &str = match option_env!("PATR_BUILD_VERSION") {
+		Some(v) => v,
+		None => env!("CARGO_PKG_VERSION"),
+	};
+
+	/// GitHub `OWNER/REPO` that hosts releases.
+	pub const GITHUB_REPO: &str = "patr-cloud/patr";
 }
 
 /// The location for config files for the CLI

--- a/cli/src/utils/search_and_select.rs
+++ b/cli/src/utils/search_and_select.rs
@@ -13,10 +13,15 @@ where
 	F: Fn(&str) -> Fut,
 	Fut: Future<Output = Result<Vec<T>, AppError>>,
 {
+	/// Prompt text shown above the search input.
 	message: &'a str,
+	/// Async function called with the current query; returns the result set.
 	search_fn: F,
+	/// Renders a result row into the string shown to the user.
 	display_fn: fn(&T) -> String,
+	/// Optional dimmed hint shown below the prompt.
 	help_message: Option<&'a str>,
+	/// Number of results shown per page when paginating.
 	page_size: usize,
 }
 

--- a/cli/src/utils/storage.rs
+++ b/cli/src/utils/storage.rs
@@ -1,26 +1,86 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{fmt, path::PathBuf, str::FromStr};
 
 use config::ConfigError;
 use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
 
-/// State and stored data of the CLI
+/// A release channel the CLI can track.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "camelCase")]
+#[value(rename_all = "kebab-case")]
+pub enum Channel {
+	/// Tracks `master` — stable releases.
+	Stable,
+	/// Tracks `staging` — pre-release builds, ahead of stable.
+	Beta,
+	/// Tracks `develop` — bleeding edge, updated on every commit.
+	Alpha,
+}
+
+impl Channel {
+	/// The channel this binary was built on. Falls back to [`Channel::Alpha`]
+	/// for local/dev builds where CI hasn't set `PATR_BUILD_CHANNEL`.
+	pub const BUILD: Self = {
+		match option_env!("PATR_BUILD_CHANNEL") {
+			Some(s) => match s.as_bytes() {
+				b"stable" => Self::Stable,
+				b"beta" => Self::Beta,
+				_ => Self::Alpha,
+			},
+			None => Self::Alpha,
+		}
+	};
+}
+
+impl Default for Channel {
+	fn default() -> Self {
+		Self::BUILD
+	}
+}
+
+impl fmt::Display for Channel {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.write_str(match self {
+			Self::Stable => "stable",
+			Self::Beta => "beta",
+			Self::Alpha => "alpha",
+		})
+	}
+}
+
+/// Auth portion of the CLI state. Kept as an enum so that
+/// `current_workspace` can't exist without a `token`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(untagged)]
-pub enum AppState {
-	/// The state of the CLI when the user is logged in
+pub enum AuthState {
+	/// The user is logged in with an API token and (optionally) a selected
+	/// workspace.
 	#[serde(rename_all = "camelCase")]
 	LoggedIn {
-		/// The user's access token
+		/// The user's access token.
 		token: BearerToken,
-		/// The current workspace that is selected by the user
+		/// The currently selected workspace id.
 		current_workspace: Option<Uuid>,
 	},
-	/// The state of the CLI when the user is logged out
-	#[serde(rename_all = "camelCase")]
+	/// The user is logged out.
 	#[default]
 	LoggedOut,
+}
+
+/// State and stored data of the CLI. Written to a single `config.json` whether
+/// or not the user is logged in; the `target_channel` field persists across
+/// login/logout.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AppState {
+	/// Release channel that `patr upgrade` tracks. Defaults to the channel
+	/// the binary was built on.
+	#[serde(default)]
+	pub target_channel: Channel,
+	/// Auth state — logged in with a token, or logged out.
+	#[serde(flatten, default)]
+	pub auth: AuthState,
 }
 
 impl AppState {
@@ -83,11 +143,11 @@ impl AppState {
 
 	/// Returns true if the user is logged in, false otherwise.
 	pub fn is_logged_in(&self) -> bool {
-		matches!(self, Self::LoggedIn { .. })
+		matches!(self.auth, AuthState::LoggedIn { .. })
 	}
 
 	/// Returns true if the user is logged out, false otherwise.
 	pub fn is_logged_out(&self) -> bool {
-		matches!(self, Self::LoggedOut)
+		matches!(self.auth, AuthState::LoggedOut)
 	}
 }

--- a/cli/src/utils/storage.rs
+++ b/cli/src/utils/storage.rs
@@ -51,7 +51,12 @@ impl fmt::Display for Channel {
 
 /// Auth portion of the CLI state. Kept as an enum so that
 /// `current_workspace` can't exist without a `token`.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+///
+/// Both variants use struct syntax (including the empty `LoggedOut {}`) so
+/// that `#[serde(flatten)]` on the containing `AppState` works: flatten
+/// requires each variant to serialize as a map, and a unit variant would
+/// serialize as `null` and break round-tripping.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AuthState {
 	/// The user is logged in with an API token and (optionally) a selected
@@ -63,9 +68,14 @@ pub enum AuthState {
 		/// The currently selected workspace id.
 		current_workspace: Option<Uuid>,
 	},
-	/// The user is logged out.
-	#[default]
-	LoggedOut,
+	/// The user is logged out. Serializes as `{}` so it flattens cleanly.
+	LoggedOut {},
+}
+
+impl Default for AuthState {
+	fn default() -> Self {
+		Self::LoggedOut {}
+	}
 }
 
 /// State and stored data of the CLI. Written to a single `config.json` whether
@@ -148,6 +158,6 @@ impl AppState {
 
 	/// Returns true if the user is logged out, false otherwise.
 	pub fn is_logged_out(&self) -> bool {
-		matches!(self.auth, AuthState::LoggedOut)
+		matches!(self.auth, AuthState::LoggedOut {})
 	}
 }

--- a/cli/src/utils/storage.rs
+++ b/cli/src/utils/storage.rs
@@ -153,11 +153,11 @@ impl AppState {
 
 	/// Returns true if the user is logged in, false otherwise.
 	pub fn is_logged_in(&self) -> bool {
-		matches!(self.auth, AuthState::LoggedIn { .. })
+		matches!(&self.auth, AuthState::LoggedIn { .. })
 	}
 
 	/// Returns true if the user is logged out, false otherwise.
 	pub fn is_logged_out(&self) -> bool {
-		matches!(self.auth, AuthState::LoggedOut {})
+		matches!(&self.auth, AuthState::LoggedOut {})
 	}
 }


### PR DESCRIPTION
Stacked on #213.

Adds `patr upgrade` (stable/beta/alpha channels, semver no-downgrade, `sudo install` fallback), `patr uninstall` (configs + systemd services + binary, `--purge` also runs `docker swarm leave --force`), and `assets/cli/install.sh` for the `curl | sh` one-liner.

Nests the old `install-service` under `patr runner service {install, uninstall, status}`.

Homebrew builds go through the new `package-managed` cargo feature — with it on, `upgrade` and `uninstall` refuse and defer to the package manager. CI builds parallel `-brew` artifacts.

Also refactors `AppState` into a struct with a nested `AuthState` enum so `current_workspace` can't exist without a token, and bakes `PATR_BUILD_VERSION` into every binary + uploads a `version.txt` release asset so the client can resolve channel versions without parsing tag names.