### PR TITLE
auto-detect runner in `runner current`

### DIFF
--- a/cli/src/commands/workspaced/runner/current.rs
+++ b/cli/src/commands/workspaced/runner/current.rs
@@ -1,11 +1,11 @@
-use std::path::PathBuf;
-
 use clap::Args as ClapArgs;
 use comfy_table::Table;
 use common::prelude::{RunnerMode, RunnerSettings};
 use docker::prelude::DockerSettings;
 use models::api::workspace::runner::*;
 use serde::Serialize;
+use serde_json::Value;
+use strum::IntoEnumIterator as _;
 
 use crate::prelude::*;
 
@@ -24,28 +24,60 @@ struct SelfHostedOutput {
 
 /// The arguments for the `runner current` command.
 #[derive(Debug, Clone, ClapArgs)]
-pub struct Args {
-	/// The type of runner configured on this host
-	#[arg(value_enum)]
-	pub runner_type: RunnerType,
-	/// Path to the config file (defaults to standard location for the runner
-	/// type)
-	#[arg(short = 'c', long = "config")]
-	pub config: Option<PathBuf>,
+pub struct Args {}
+
+/// Print information about the runner(s) configured on this host. Auto-detects
+/// which runner type(s) are set up by looking for their config files — no
+/// positional argument needed.
+pub(super) async fn execute(_args: Args) -> Result<CommandOutput, AppError> {
+	let configured = RunnerType::iter()
+		.filter(|t| crate::utils::runner_config_path(*t).exists())
+		.collect::<Vec<_>>();
+
+	if configured.is_empty() {
+		return Err(AppError::RunnerError(
+			"No runner is configured on this host. Run `patr runner setup` to configure one."
+				.to_string(),
+		));
+	}
+
+	let multi = configured.len() > 1;
+	let mut text_blocks = Vec::<String>::with_capacity(configured.len());
+	let mut json_items = Vec::<Value>::with_capacity(configured.len());
+
+	for runner_type in configured {
+		let (table, json) = render_runner(runner_type).await?;
+		let block = if multi {
+			let header = match runner_type {
+				RunnerType::Docker => "== docker ==",
+				RunnerType::Kubernetes => "== kubernetes ==",
+			};
+			format!("{header}\n{table}")
+		} else {
+			table
+		};
+		text_blocks.push(block);
+		json_items.push(json);
+	}
+
+	CommandOutput::builder()
+		.text(text_blocks.join("\n\n"))
+		.json(Value::Array(json_items))
+		.build()
+		.into_result()
 }
 
-/// Print information about the runner configured on this host.
-pub(super) async fn execute(args: Args) -> Result<CommandOutput, AppError> {
-	match args.runner_type {
+/// Render a single configured runner — returns the text table plus the JSON
+/// value that represents it.
+async fn render_runner(runner_type: RunnerType) -> Result<(String, Value), AppError> {
+	match runner_type {
 		RunnerType::Kubernetes => {
 			todo!("Kubernetes runner is not yet supported")
 		}
 		RunnerType::Docker => {}
 	}
 
-	let config_path = args
-		.config
-		.unwrap_or_else(|| crate::utils::runner_config_path(args.runner_type));
+	let config_path = crate::utils::runner_config_path(runner_type);
 
 	let config_str = std::fs::read_to_string(&config_path).map_err(|e| {
 		AppError::RunnerError(format!(
@@ -57,7 +89,7 @@ pub(super) async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 	let config: RunnerSettings<DockerSettings> = serde_json::from_str(&config_str)
 		.map_err(|e| AppError::RunnerError(format!("Failed to parse config: {e}")))?;
 
-	let runner_type_str = match args.runner_type {
+	let runner_type_str = match runner_type {
 		RunnerType::Docker => "docker",
 		RunnerType::Kubernetes => "kubernetes",
 	};
@@ -68,18 +100,13 @@ pub(super) async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 			table.add_row(["Config".to_string(), config_path.display().to_string()]);
 			table.add_row(["Type".to_string(), runner_type_str.to_string()]);
 			table.add_row(["Mode".to_string(), "Self-hosted".to_string()]);
-			CommandOutput::builder()
-				.text(table.to_string())
-				.json(
-					SelfHostedOutput {
-						config: config_path.display().to_string(),
-						runner_type: runner_type_str.to_string(),
-						mode: "selfHosted",
-					}
-					.to_json_value(),
-				)
-				.build()
-				.into_result()
+			let json = SelfHostedOutput {
+				config: config_path.display().to_string(),
+				runner_type: runner_type_str.to_string(),
+				mode: "selfHosted",
+			}
+			.to_json_value();
+			Ok((table.to_string(), json))
 		}
 		RunnerMode::Managed {
 			workspace_id,
@@ -118,11 +145,8 @@ pub(super) async fn execute(args: Args) -> Result<CommandOutput, AppError> {
 			table.add_row(["Runner Name".to_string(), runner.data.name.clone()]);
 			table.add_row(["Status".to_string(), connected.to_string()]);
 
-			CommandOutput::builder()
-				.text(table.to_string())
-				.json(GetRunnerInfoResponse { runner }.to_json_value())
-				.build()
-				.into_result()
+			let json = GetRunnerInfoResponse { runner }.to_json_value();
+			Ok((table.to_string(), json))
 		}
 	}
 }


### PR DESCRIPTION
`patr runner current` (and its aliases `info` / `status` / `whoami`) now auto-detects the configured runner instead of requiring the type as a positional arg, and prints a clean "no runner is configured — run \`patr runner setup\`" message instead of leaking a raw OS error when nothing is set up.

If multiple runner configs exist on the host, each is rendered under a `== <type> ==` header separated by a blank line. JSON output is now always an array for uniformity.