### PR TITLE
Speed up registry push finalize via parallel multipart-copy

### DIFF
--- a/api/src/routes/registry.patr.cloud/handlers/blob/complete_upload.rs
+++ b/api/src/routes/registry.patr.cloud/handlers/blob/complete_upload.rs
@@ -499,15 +499,12 @@ pub async fn complete_upload(
 							.part_number(part_number)
 							.send()
 							.await?;
-						let etag = out
-							.copy_part_result
-							.and_then(|r| r.e_tag)
-							.ok_or_else(|| {
-								RegistryError::server_error(
-									ErrorCode::BlobUploadInvalid,
-									"S3 UploadPartCopy returned no ETag",
-								)
-							})?;
+						let etag = out.copy_part_result.and_then(|r| r.e_tag).ok_or_else(|| {
+							RegistryError::server_error(
+								ErrorCode::BlobUploadInvalid,
+								"S3 UploadPartCopy returned no ETag",
+							)
+						})?;
 						Ok::<_, RegistryError>(
 							CompletedPart::builder()
 								.part_number(part_number)

--- a/api/src/routes/registry.patr.cloud/handlers/blob/complete_upload.rs
+++ b/api/src/routes/registry.patr.cloud/handlers/blob/complete_upload.rs
@@ -443,15 +443,124 @@ pub async fn complete_upload(
 	info!("Digest verification successful");
 
 	if inserted {
-		s3.copy_object()
-			.bucket(&config.s3.bucket)
-			.copy_source(format!(
-				"{}/registry/uploads/{session_id}",
-				config.s3.bucket
-			))
-			.key(format!("registry/blobs/{}", digest))
-			.send()
-			.await?;
+		let total_bytes = updated_session.total_bytes_uploaded;
+		let source_key = format!("registry/uploads/{session_id}");
+		let dest_key = format!("registry/blobs/{digest}");
+		let copy_source = format!("{}/{source_key}", config.s3.bucket);
+
+		if total_bytes < constants::REGISTRY_BLOB_FINAL_COPY_MULTIPART_THRESHOLD {
+			s3.copy_object()
+				.bucket(&config.s3.bucket)
+				.copy_source(&copy_source)
+				.key(&dest_key)
+				.send()
+				.await?;
+		} else {
+			// Mirrors cncf/distribution's S3 driver: for large blobs the
+			// single-shot CopyObject is replaced by a multipart upload at the
+			// destination keyed by `dest_key`, with parallel UploadPartCopy
+			// requests fanning across byte ranges of the source. Also lifts the
+			// 5 GB CopyObject ceiling — S3 mandates multipart copy above that.
+			let upload_id = s3
+				.create_multipart_upload()
+				.bucket(&config.s3.bucket)
+				.key(&dest_key)
+				.send()
+				.await?
+				.upload_id
+				.ok_or_else(|| {
+					RegistryError::server_error(
+						ErrorCode::BlobUploadInvalid,
+						"S3 did not return an upload_id for multipart copy",
+					)
+				})?;
+
+			let chunk = constants::REGISTRY_BLOB_FINAL_COPY_CHUNK_SIZE;
+			let part_count = total_bytes.div_ceil(chunk);
+
+			let part_copy = futures::stream::iter(0..part_count)
+				.map(|index| {
+					let start = index * chunk;
+					let end = (start + chunk).min(total_bytes) - 1;
+					let part_number = (index + 1) as i32;
+					let s3 = &s3;
+					let bucket = &config.s3.bucket;
+					let copy_source = &copy_source;
+					let dest_key = &dest_key;
+					let upload_id = &upload_id;
+					async move {
+						let out = s3
+							.upload_part_copy()
+							.bucket(bucket)
+							.key(dest_key)
+							.upload_id(upload_id)
+							.copy_source(copy_source)
+							.copy_source_range(format!("bytes={start}-{end}"))
+							.part_number(part_number)
+							.send()
+							.await?;
+						let etag = out
+							.copy_part_result
+							.and_then(|r| r.e_tag)
+							.ok_or_else(|| {
+								RegistryError::server_error(
+									ErrorCode::BlobUploadInvalid,
+									"S3 UploadPartCopy returned no ETag",
+								)
+							})?;
+						Ok::<_, RegistryError>(
+							CompletedPart::builder()
+								.part_number(part_number)
+								.e_tag(etag)
+								.build(),
+						)
+					}
+				})
+				.buffer_unordered(constants::REGISTRY_BLOB_FINAL_COPY_CONCURRENCY)
+				.try_collect::<Vec<_>>()
+				.await;
+
+			let mut parts = match part_copy {
+				Ok(parts) => parts,
+				Err(err) => {
+					error!("UploadPartCopy failed, aborting multipart copy: {err}");
+					let _ = s3
+						.abort_multipart_upload()
+						.bucket(&config.s3.bucket)
+						.key(&dest_key)
+						.upload_id(&upload_id)
+						.send()
+						.await;
+					return Err(err);
+				}
+			};
+			parts.sort_by_key(|p| p.part_number());
+
+			let complete = s3
+				.complete_multipart_upload()
+				.bucket(&config.s3.bucket)
+				.key(&dest_key)
+				.upload_id(&upload_id)
+				.multipart_upload(
+					CompletedMultipartUpload::builder()
+						.set_parts(Some(parts))
+						.build(),
+				)
+				.send()
+				.await;
+
+			if let Err(err) = complete {
+				error!("CompleteMultipartUpload failed, aborting multipart copy: {err}");
+				let _ = s3
+					.abort_multipart_upload()
+					.bucket(&config.s3.bucket)
+					.key(&dest_key)
+					.upload_id(&upload_id)
+					.send()
+					.await;
+				return Err(err.into());
+			}
+		}
 	}
 
 	let _ = s3

--- a/api/src/routes/registry.patr.cloud/handlers/blob/upload_chunk.rs
+++ b/api/src/routes/registry.patr.cloud/handlers/blob/upload_chunk.rs
@@ -397,17 +397,18 @@ pub async fn upload_chunk(
 				"/v2/{workspace_id}/{repo_name}/blobs/uploads/{session_id}"
 			))?,
 			docker_upload_uuid: DockerUploadUuid::new(session_id),
-			range: Range::new(0..updated_session.total_bytes_uploaded + pending_size_after).map_err(|err| {
-				error!("Invalid range error: {}", err);
-				RegistryError::server_error(
-					ErrorCode::BlobUploadInvalid,
-					if cfg!(debug_assertions) {
-						format!("invalid range specified: {}", err)
-					} else {
-						"invalid range specified".to_string()
-					},
-				)
-			})?,
+			range: Range::new(0..updated_session.total_bytes_uploaded + pending_size_after)
+				.map_err(|err| {
+					error!("Invalid range error: {}", err);
+					RegistryError::server_error(
+						ErrorCode::BlobUploadInvalid,
+						if cfg!(debug_assertions) {
+							format!("invalid range specified: {}", err)
+						} else {
+							"invalid range specified".to_string()
+						},
+					)
+				})?,
 		})
 		.body(Body::empty())
 		.build()

--- a/api/src/routes/registry.patr.cloud/handlers/blob/upload_chunk.rs
+++ b/api/src/routes/registry.patr.cloud/handlers/blob/upload_chunk.rs
@@ -204,15 +204,44 @@ pub async fn upload_chunk(
 			.into_result();
 	}
 
+	// Load any pending buffer from a previous PATCH that was under 5 MB. We
+	// need its size before the Content-Range check below so that the byte
+	// position we compare against reflects bytes received (S3 + Redis), not
+	// just bytes flushed to S3.
+	let pending_key = keys::registry_blob_upload_pending_buffer(&session_id);
+	let buffer = redis
+		.get::<Option<String>>(&pending_key)
+		.await?
+		.map(|encoded| {
+			// If there's any pending buffer, decode it from base64 and prepend it to the
+			// body stream
+			info!("Loaded pending buffer from Redis");
+			BASE64_STANDARD.decode(&encoded).map_err(|err| {
+				error!("Failed to decode pending buffer from Redis: {err}");
+				RegistryError::server_error(
+					ErrorCode::BlobUploadInvalid,
+					"Corrupted pending upload buffer",
+				)
+			})
+		})
+		.transpose()?
+		.unwrap_or_default();
+	// Clean up the pending buffer in Redis since we're now processing it (if it
+	// exists) If something goes wrong during processing, the client can re-upload
+	// the blob
+	let _ = redis.del(&pending_key).await;
+
+	let pending_size_before = buffer.len() as u64;
+
 	if let Some(content_range) = content_range.into_option() {
 		let start_range = content_range
 			.bytes_range()
 			.map(|range| range.0)
 			.unwrap_or_default();
-		if start_range != session.total_bytes_uploaded {
+		let received_so_far = session.total_bytes_uploaded + pending_size_before;
+		if start_range != received_so_far {
 			warn!(
-				"Content-Range start is {start_range} but last byte position is {}",
-				session.total_bytes_uploaded
+				"Content-Range start is {start_range} but last byte position is {received_so_far}"
 			);
 			return RegistryError::builder()
 				.code(ErrorCode::BlobUploadInvalid)
@@ -243,31 +272,7 @@ pub async fn upload_chunk(
 	// Upload chunk to S3
 	const CHUNK_FLUSH_THRESHOLD: u64 = 5 * 1024 * 1024; // 5 MB - S3 requires all non-final parts to be at least this size
 
-	// Load any pending buffer from a previous PATCH that was under 5 MB
-	let pending_key = keys::registry_blob_upload_pending_buffer(&session_id);
-	let buffer = redis
-		.get::<Option<String>>(&pending_key)
-		.await?
-		.map(|encoded| {
-			// If there's any pending buffer, decode it from base64 and prepend it to the
-			// body stream
-			info!("Loaded pending buffer from Redis");
-			BASE64_STANDARD.decode(&encoded).map_err(|err| {
-				error!("Failed to decode pending buffer from Redis: {err}");
-				RegistryError::server_error(
-					ErrorCode::BlobUploadInvalid,
-					"Corrupted pending upload buffer",
-				)
-			})
-		})
-		.transpose()?
-		.unwrap_or_default();
-	// Clean up the pending buffer in Redis since we're now processing it (if it
-	// exists) If something goes wrong during processing, the client can re-upload
-	// the blob
-	let _ = redis.del(&pending_key).await;
-
-	let (mut updated_session, hasher, _) =
+	let (mut updated_session, hasher, _, pending_size_after) =
 		futures::stream::once(async move { Ok(Bytes::from(buffer)) })
 			.chain(body.into_data_stream().map_err(|err| {
 				error!("Failed to read body stream: {err}");
@@ -284,8 +289,9 @@ pub async fn upload_chunk(
 					session,
 					hasher,
 					None::<JoinHandle<Result<UploadPartOutput, SdkError<UploadPartError>>>>,
+					0u64,
 				),
-				async |(mut session, mut hasher, inflight_task), chunk| {
+				async |(mut session, mut hasher, inflight_task, mut pending_size_after), chunk| {
 					// If there's an inflight upload task from the previous chunk, await it and
 					// update the session with the returned ETag and part number
 					if let Some(task) = inflight_task {
@@ -340,9 +346,11 @@ pub async fn upload_chunk(
 							// is if it's the final chunk (the stream ended) — in that case
 							// we can store that final chunk in Redis as a pending buffer to
 							// be flushed on the next PATCH, which avoids violating S3's
-							// minimum part size requirement for non-final parts
+							// minimum part size requirement for non-final parts. These bytes
+							// aren't in S3 yet so they don't move `total_bytes_uploaded`; the
+							// outgoing `Range:` header adds `pending_size_after` to reflect
+							// bytes received (vs. bytes flushed to S3).
 							info!("Storing {} pending buffer in Redis", chunk_size_string);
-							// session.total_bytes_uploaded += chunk_size as u64;
 							redis
 								.setex(
 									&pending_key,
@@ -350,8 +358,7 @@ pub async fn upload_chunk(
 									BASE64_STANDARD.encode(&chunk),
 								)
 								.await?;
-
-							session.total_bytes_uploaded += chunk_size as u64;
+							pending_size_after = chunk_size as u64;
 							None
 						}
 						CHUNK_FLUSH_THRESHOLD.. => {
@@ -366,7 +373,7 @@ pub async fn upload_chunk(
 						}
 					};
 
-					Ok((session, hasher, inflight_task))
+					Ok((session, hasher, inflight_task, pending_size_after))
 				},
 			)
 			.await?;
@@ -390,7 +397,7 @@ pub async fn upload_chunk(
 				"/v2/{workspace_id}/{repo_name}/blobs/uploads/{session_id}"
 			))?,
 			docker_upload_uuid: DockerUploadUuid::new(session_id),
-			range: Range::new(0..updated_session.total_bytes_uploaded).map_err(|err| {
+			range: Range::new(0..updated_session.total_bytes_uploaded + pending_size_after).map_err(|err| {
 				error!("Invalid range error: {}", err);
 				RegistryError::server_error(
 					ErrorCode::BlobUploadInvalid,

--- a/api/src/utils/mod.rs
+++ b/api/src/utils/mod.rs
@@ -166,4 +166,21 @@ pub mod constants {
 	/// upload a manifest larger than this size, they can contact support to
 	/// have the limit increased for their account.
 	pub const MAX_REGISTRY_MANIFEST_SIZE: usize = 100 * 1024 * 1024; // 100 MiB
+
+	/// Size at or above which the final blob copy (from the session-keyed
+	/// upload key to the digest-keyed final key) switches from a single
+	/// `CopyObject` to a multipart copy with parallel `UploadPartCopy`. Matches
+	/// cncf/distribution's `multipartcopythresholdsize` default.
+	pub const REGISTRY_BLOB_FINAL_COPY_MULTIPART_THRESHOLD: u64 = 32 * 1024 * 1024;
+
+	/// Byte range size for each `UploadPartCopy` request during the final blob
+	/// copy. Must be ≥ 5 MiB (S3 minimum part size, except the last part). At
+	/// 32 MiB, the 10,000-part S3 cap accommodates blobs up to 320 GB.
+	pub const REGISTRY_BLOB_FINAL_COPY_CHUNK_SIZE: u64 = 32 * 1024 * 1024;
+
+	/// Maximum in-flight `UploadPartCopy` requests for the final blob copy.
+	/// Higher helps on AWS S3 / distributed object stores; on a single-node
+	/// MinIO it saturates local disk I/O before this many threads do useful
+	/// work.
+	pub const REGISTRY_BLOB_FINAL_COPY_CONCURRENCY: usize = 10;
 }

--- a/api/tests/registry/blob.rs
+++ b/api/tests/registry/blob.rs
@@ -381,7 +381,9 @@ async fn chunked_upload_with_patch_under_threshold() {
 	assert_eq!(get_response.status_code(), StatusCode::OK);
 	assert_eq!(get_response.into_bytes().as_ref(), &data);
 
-	setup.assert_blob_size_in_db(&digest, data.len() as u64).await;
+	setup
+		.assert_blob_size_in_db(&digest, data.len() as u64)
+		.await;
 }
 
 #[tokio::test]

--- a/api/tests/registry/blob.rs
+++ b/api/tests/registry/blob.rs
@@ -367,7 +367,7 @@ async fn chunked_upload_with_patch_under_threshold() {
 			path: GetBlobPath {
 				workspace_id: workspace.id,
 				repo_name: repo.name.clone(),
-				digest,
+				digest: digest.clone(),
 			},
 			query: (),
 			headers: GetBlobRequestHeaders {
@@ -380,6 +380,8 @@ async fn chunked_upload_with_patch_under_threshold() {
 
 	assert_eq!(get_response.status_code(), StatusCode::OK);
 	assert_eq!(get_response.into_bytes().as_ref(), &data);
+
+	setup.assert_blob_size_in_db(&digest, data.len() as u64).await;
 }
 
 #[tokio::test]
@@ -457,7 +459,7 @@ async fn chunked_upload_with_patch_over_threshold() {
 			path: GetBlobPath {
 				workspace_id: workspace.id,
 				repo_name: repo.name.clone(),
-				digest,
+				digest: digest.clone(),
 			},
 			query: (),
 			headers: GetBlobRequestHeaders {
@@ -470,6 +472,8 @@ async fn chunked_upload_with_patch_over_threshold() {
 
 	assert_eq!(get_response.status_code(), StatusCode::OK);
 	assert_eq!(get_response.into_bytes().len(), size);
+
+	setup.assert_blob_size_in_db(&digest, size as u64).await;
 }
 
 #[tokio::test]
@@ -575,7 +579,7 @@ async fn chunked_upload_multiple_patches() {
 			path: GetBlobPath {
 				workspace_id: workspace.id,
 				repo_name: repo.name.clone(),
-				digest,
+				digest: digest.clone(),
 			},
 			query: (),
 			headers: GetBlobRequestHeaders {
@@ -588,6 +592,10 @@ async fn chunked_upload_multiple_patches() {
 
 	assert_eq!(get_response.status_code(), StatusCode::OK);
 	assert_eq!(get_response.into_bytes().len(), part1_size + part2_size);
+
+	setup
+		.assert_blob_size_in_db(&digest, (part1_size + part2_size) as u64)
+		.await;
 }
 
 #[tokio::test]
@@ -669,7 +677,7 @@ async fn chunked_upload_patch_then_body_in_put() {
 			path: GetBlobPath {
 				workspace_id: workspace.id,
 				repo_name: repo.name.clone(),
-				digest,
+				digest: digest.clone(),
 			},
 			query: (),
 			headers: GetBlobRequestHeaders {
@@ -682,4 +690,104 @@ async fn chunked_upload_patch_then_body_in_put() {
 
 	assert_eq!(get_response.status_code(), StatusCode::OK);
 	assert_eq!(get_response.into_bytes().as_ref(), &combined);
+
+	setup
+		.assert_blob_size_in_db(&digest, combined.len() as u64)
+		.await;
+}
+
+/// Pushes a blob larger than the multipart-copy threshold so the finalize
+/// step exercises the `UploadPartCopy` fan-out at `registry/blobs/<digest>`
+/// instead of the single-shot `CopyObject` branch. Catches regressions in
+/// the byte-range math and dest-key wiring.
+#[tokio::test]
+async fn chunked_upload_exercises_multipart_copy() {
+	use api::utils::constants::REGISTRY_BLOB_FINAL_COPY_MULTIPART_THRESHOLD;
+
+	let setup = setup().await.expect("failed to setup test server");
+	let user = setup.create_test_user().await;
+	let workspace = setup.create_test_workspace(&user.access_token).await;
+	let repo = setup
+		.create_test_container_repo(&user.access_token, workspace.id)
+		.await;
+	let api_token = setup
+		.create_test_api_token(
+			&user.access_token,
+			BTreeMap::from([(workspace.id, WorkspacePermission::SuperAdmin)]),
+		)
+		.await;
+
+	let (session_id, _) = setup
+		.initiate_chunked_upload(&api_token.token, &workspace.id, &repo.name)
+		.await;
+
+	// One byte past the threshold so finalize takes the multipart-copy branch.
+	let size = (REGISTRY_BLOB_FINAL_COPY_MULTIPART_THRESHOLD as usize) + 1;
+	let data: Vec<u8> = (0..=255u8).cycle().take(size).collect();
+	let digest = sha256_digest(&data);
+
+	let patch_response = setup
+		.patch_blob_chunk(
+			&api_token.token,
+			&workspace.id,
+			&repo.name,
+			session_id,
+			&data,
+		)
+		.await;
+	assert_eq!(
+		patch_response.status_code(),
+		StatusCode::ACCEPTED,
+		"PATCH chunk failed: {}",
+		std::str::from_utf8(&patch_response.into_bytes()).unwrap_or("<non-utf8>")
+	);
+
+	let response = setup
+		.make_registry_call(RegistryUnprocessedApiRequest::<CompleteBlobUploadPath> {
+			path: CompleteBlobUploadPath {
+				workspace_id: workspace.id,
+				repo_name: repo.name.clone(),
+				session_id,
+			},
+			query: CompleteBlobUploadQuery {
+				digest: digest.clone(),
+			},
+			headers: CompleteBlobUploadRequestHeaders {
+				authorization: BearerToken::from_str(&api_token.token).unwrap(),
+				content_type: OptionalHeader::new(None),
+				content_length: OptionalHeader::new(None),
+				content_range: OptionalHeader::new(None),
+			},
+			body: Body::empty(),
+		})
+		.await;
+	assert_eq!(
+		response.status_code(),
+		StatusCode::CREATED,
+		"complete upload failed: {}",
+		std::str::from_utf8(&response.into_bytes()).unwrap_or("<non-utf8>")
+	);
+
+	let get_response = setup
+		.make_registry_call(RegistryUnprocessedApiRequest::<GetBlobPath> {
+			path: GetBlobPath {
+				workspace_id: workspace.id,
+				repo_name: repo.name.clone(),
+				digest: digest.clone(),
+			},
+			query: (),
+			headers: GetBlobRequestHeaders {
+				authorization: BearerToken::from_str(&api_token.token).unwrap(),
+				range: OptionalHeader::new(None),
+			},
+			body: Body::empty(),
+		})
+		.await;
+
+	assert_eq!(get_response.status_code(), StatusCode::OK);
+	let bytes = get_response.into_bytes();
+	assert_eq!(bytes.len(), size);
+	assert_eq!(bytes.as_ref(), data.as_slice());
+
+	setup.assert_blob_size_in_db(&digest, size as u64).await;
 }

--- a/api/tests/registry/helpers.rs
+++ b/api/tests/registry/helpers.rs
@@ -141,6 +141,24 @@ pub fn build_minimal_oci_image_with_ports(seed: u8, exposed_tcp_ports: &[u16]) -
 }
 
 impl TestSetup {
+	/// Assert that `container_registry_blob.size` for the given digest equals
+	/// `expected`. Guards against regressions where `total_bytes_uploaded`
+	/// drifts from the actual S3 object size — e.g. by double-counting bytes
+	/// that crossed a request boundary via the Redis pending buffer.
+	pub async fn assert_blob_size_in_db(&self, digest: &str, expected: u64) {
+		let size: i64 = sqlx::query_scalar(
+			"SELECT size FROM container_registry_blob WHERE digest = $1",
+		)
+		.bind(digest)
+		.fetch_one(self.database())
+		.await
+		.unwrap_or_else(|err| panic!("blob row not found for {digest}: {err}"));
+		assert_eq!(
+			size as u64, expected,
+			"container_registry_blob.size mismatch for {digest}: got {size}, expected {expected}",
+		);
+	}
+
 	/// Initiate a chunked blob upload (POST without `?digest=`).
 	/// Returns `(session_id, location)` parsed from the response headers.
 	pub async fn initiate_chunked_upload(

--- a/api/tests/registry/helpers.rs
+++ b/api/tests/registry/helpers.rs
@@ -146,13 +146,12 @@ impl TestSetup {
 	/// drifts from the actual S3 object size — e.g. by double-counting bytes
 	/// that crossed a request boundary via the Redis pending buffer.
 	pub async fn assert_blob_size_in_db(&self, digest: &str, expected: u64) {
-		let size: i64 = sqlx::query_scalar(
-			"SELECT size FROM container_registry_blob WHERE digest = $1",
-		)
-		.bind(digest)
-		.fetch_one(self.database())
-		.await
-		.unwrap_or_else(|err| panic!("blob row not found for {digest}: {err}"));
+		let size: i64 =
+			sqlx::query_scalar("SELECT size FROM container_registry_blob WHERE digest = $1")
+				.bind(digest)
+				.fetch_one(self.database())
+				.await
+				.unwrap_or_else(|err| panic!("blob row not found for {digest}: {err}"));
 		assert_eq!(
 			size as u64, expected,
 			"container_registry_blob.size mismatch for {digest}: got {size}, expected {expected}",

--- a/api/tests/setup.rs
+++ b/api/tests/setup.rs
@@ -22,6 +22,7 @@ use api::{
 		RedisConfig,
 		RunningEnvironment,
 		S3Config,
+		ServerConfig,
 		SocialLoginConfig,
 		TracingConfig,
 	},
@@ -441,8 +442,10 @@ pub async fn setup() -> Result<TestSetup, anyhow::Error> {
 	};
 
 	let config = AppConfig {
-		bind_address: web_bind_address,
-		api_base_path: String::from("/"),
+		server: ServerConfig {
+			bind_address: web_bind_address,
+			api_base_path: String::from("/"),
+		},
 		password_pepper,
 		jwt_secret,
 		primary_hosted_domain: String::from("testonpatr.cloud"),


### PR DESCRIPTION
- swap single CopyObject for UploadPartCopy at concurrency 10 above 32 MiB
- unblocks pushes of blobs >5 GB (the single CopyObject limit)
- stop double-counting redis-pending bytes in total_bytes_uploaded
- PATCH Range and Content-Range now report counter + pending so resume still works