### PR TITLE
Roles: expandable row to manage users; log terminal polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .worktrees
 
 *.db
+*.db-journal
 *.lock
 
 dump*.sql

--- a/e2e/helpers/ui/role.ts
+++ b/e2e/helpers/ui/role.ts
@@ -77,12 +77,11 @@ export async function openRoleUsersTab(page: Page): Promise<void> {
 }
 
 export async function clickDeleteRole(page: Page, roleName: string): Promise<void> {
-  // The Button component doesn't forward aria-label, so the trash <button>
-  // has no accessible name. Each row has exactly one <button> (the trash) and
-  // one <a> (Manage Role); locate the button by being inside the row.
+  // Each row has two <button>s — the "See users" expand toggle and the trash —
+  // so locate the trash by its accessible name rather than by position.
   const row = page.getByRole('row').filter({ hasText: roleName });
   await row.scrollIntoViewIfNeeded({ timeout: 10_000 }).catch(() => {});
-  await row.locator('button').first().click();
+  await row.getByRole('button', { name: /Delete role/i }).click();
 }
 
 export async function confirmDeleteRoleModal(page: Page): Promise<void> {

--- a/frontend/src/components/initials.tsx
+++ b/frontend/src/components/initials.tsx
@@ -16,6 +16,8 @@ interface InitialsProps {
 	 * Color of the intitials
 	 */
 	color?: Color;
+	/** Background color of the circle. Defaults to `bg-secondary-dark`. */
+	bgColor?: Color;
 }
 
 const sizeClasses = {
@@ -42,9 +44,11 @@ const Initials = (rawProps: InitialsProps) => {
 		return (firstName?.slice(0, 2) ?? "??").toUpperCase();
 	};
 
+	const bgClass = () => (props.bgColor ? getColorClasses(props.bgColor).bg : "bg-secondary-dark");
+
 	return (
 		<div
-			class={`bg-secondary-dark rounded-full flex items-center justify-center font-light ${sizeClasses[props.size]} ${get(props.class)} ${getColorClasses(props.color).text}`}
+			class={`${bgClass()} rounded-full flex items-center justify-center font-light ${sizeClasses[props.size]} ${get(props.class)} ${getColorClasses(props.color).text}`}
 		>
 			{getInitials(get(props.firstName), get(props.lastName))}
 		</div>

--- a/frontend/src/components/log-line.tsx
+++ b/frontend/src/components/log-line.tsx
@@ -6,11 +6,9 @@ interface LogLineProps {
 		timestamp: Date | string;
 		log: string;
 	};
-	/** The line number to display in the gutter */
-	lineNum: number;
 }
 
-/** A single log line with line number, timestamp, and message. Terminal-style. */
+/** A single log line with timestamp and message. Terminal-style. */
 const LogLine = (props: LogLineProps) => {
 	const ts = () => {
 		const d = parseDate(props.log.timestamp);
@@ -24,10 +22,7 @@ const LogLine = (props: LogLineProps) => {
 	};
 
 	return (
-		<div class="group flex w-full font-log text-xs leading-6 hover:bg-white/[0.03] transition-colors duration-75 select-text">
-			<span class="w-10 shrink-0 text-right pr-sm text-white/15 group-hover:text-white/25 select-none tabular-nums">
-				{props.lineNum}
-			</span>
+		<div class="group flex w-full font-log text-xs leading-6 pl-4 hover:bg-white/3 transition-colors duration-75 select-text">
 			<span class="w-20 shrink-0 text-primary/60 group-hover:text-primary/80 select-none tabular-nums">
 				{ts()}
 			</span>

--- a/frontend/src/components/log-terminal.tsx
+++ b/frontend/src/components/log-terminal.tsx
@@ -1,4 +1,5 @@
 import { createWS } from "@solid-primitives/websocket";
+import { FiDownload } from "solid-icons/fi";
 import { createEffect, createSignal, For, on, onCleanup, onMount, Show } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import { createQuery } from "@tanstack/solid-query";
@@ -238,6 +239,25 @@ const LogTerminal = (props: LogTerminalProps) => {
 
 	const entryCount = () => logs.length;
 
+	const downloadLogs = () => {
+		if (logs.length === 0) return;
+		const content = logs
+			.map((entry) => {
+				const ts = typeof entry.timestamp === "string" ? entry.timestamp : entry.timestamp.toISOString();
+				return `${ts}\t${entry.log}`;
+			})
+			.join("\n");
+		const blob = new Blob([content], { type: "text/plain" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = `logs-${new Date().toISOString().replace(/[:.]/g, "-")}.log`;
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+		URL.revokeObjectURL(url);
+	};
+
 	return (
 		<div
 			class="w-full flex flex-col overflow-hidden rounded-xs border border-border-color"
@@ -292,6 +312,19 @@ const LogTerminal = (props: LogTerminalProps) => {
 
 				{/* Entry count */}
 				<span class="text-xxs text-white/30 font-log shrink-0 tabular-nums">{entryCount()} entries</span>
+
+				{/* Download button */}
+				<button
+					type="button"
+					onClick={downloadLogs}
+					disabled={entryCount() === 0}
+					title="Download logs"
+					aria-label="Download logs"
+					class="shrink-0 flex items-center gap-xxs p-1 text-xxs font-medium text-white/40 hover:text-white/80 disabled:text-white/10 disabled:cursor-not-allowed transition-colors"
+				>
+					<FiDownload size={14} />
+					<span>Download logs</span>
+				</button>
 			</div>
 
 			{/* Log body */}
@@ -332,7 +365,7 @@ const LogTerminal = (props: LogTerminalProps) => {
 						</div>
 					}
 				>
-					<For each={logs}>{(log, i) => <LogLine log={log} lineNum={i() + 1} />}</For>
+					<For each={logs}>{(log) => <LogLine log={log} />}</For>
 				</Show>
 			</div>
 		</div>

--- a/frontend/src/hooks/fetch/user-permissions.tsx
+++ b/frontend/src/hooks/fetch/user-permissions.tsx
@@ -9,21 +9,6 @@ import { ActionTypes, ResourceTypes, UserPermissionsT } from "~/utils/types";
 
 type ParsedPermission = { resourceType: string; permission: string };
 
-const getCachedPermissions = (wsId: string): UserPermissionsT | undefined => {
-	if (typeof window === "undefined") return undefined;
-	try {
-		const cached = sessionStorage.getItem(`user-permissions-map:${wsId}`);
-		return cached ? JSON.parse(cached) : undefined;
-	} catch {
-		return undefined;
-	}
-};
-
-const setCachedPermissions = (wsId: string, data: UserPermissionsT) => {
-	if (typeof window === "undefined") return;
-	sessionStorage.setItem(`user-permissions-map:${wsId}`, JSON.stringify(data));
-};
-
 /**
  * Utility function to fetch all permissions for a workspace and map them
  * to their resourceType and action.
@@ -58,7 +43,6 @@ const useUserPermissionsQuery = () => {
 			meta: { errorMessage: "Failed to fetch user permissions" },
 			staleTime: 5 * 60 * 1000,
 			gcTime: 30 * 60 * 1000,
-			initialData: () => getCachedPermissions(wsId ?? ""),
 			queryFn: async (): Promise<UserPermissionsT> => {
 				const [permissions, response] = await Promise.all([
 					getPermissions(wsId!),
@@ -86,7 +70,6 @@ const useUserPermissionsQuery = () => {
 				const userPermission = response.data;
 
 				if (userPermission.type !== "member") {
-					setCachedPermissions(wsId!, userPermission as UserPermissionsT);
 					return userPermission as UserPermissionsT;
 				}
 
@@ -116,7 +99,6 @@ const useUserPermissionsQuery = () => {
 					});
 				}
 
-				setCachedPermissions(wsId!, detailedPermissions);
 				return detailedPermissions;
 			},
 		};

--- a/frontend/src/routes/_logged-in/_workspaced/workspace/roles/-components/role-users-chips.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/workspace/roles/-components/role-users-chips.tsx
@@ -115,12 +115,17 @@ const RoleUsersChips = (props: RoleUsersChipsProps) => {
 						<For each={usersQuery.data ?? []}>
 							{(user) => (
 								<div class="flex items-center gap-1.5 bg-secondary rounded-full pl-1 pr-1 py-0.5 text-xs text-white">
-									<Initials bgColor={Color.Secondary} firstName={user.firstName} lastName={user.lastName} size="xs" />
+									<Initials
+										bgColor={Color.Secondary}
+										firstName={user.firstName}
+										lastName={user.lastName}
+										size="xs"
+									/>
 									<span class="font-mono truncate max-w-40">{user.username}</span>
 									<button
 										type="button"
 										aria-label={`Remove ${user.username} from role`}
-										onClick={() => removeUser(user.id, user.username).catch(() => { })}
+										onClick={() => removeUser(user.id, user.username).catch(() => {})}
 										disabled={!canMutate()}
 										class="text-grey hover:text-error transition-colors p-0.5 rounded-full cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
 									>
@@ -142,7 +147,7 @@ const RoleUsersChips = (props: RoleUsersChipsProps) => {
 				/>
 				<Button
 					variant={ButtonVariant.Outlined}
-					onClick={() => addUser().catch(() => { })}
+					onClick={() => addUser().catch(() => {})}
 					disabled={!pickedUser() || !canMutate()}
 					loading={isMutating()}
 					class="flex items-center gap-2"

--- a/frontend/src/routes/_logged-in/_workspaced/workspace/roles/-components/role-users-chips.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/workspace/roles/-components/role-users-chips.tsx
@@ -1,0 +1,158 @@
+import { useQueryClient } from "@tanstack/solid-query";
+import { FiUserPlus, FiX } from "solid-icons/fi";
+import { createSignal, For, Show } from "solid-js";
+import { Button, ButtonVariant, Initials, LoadingSpinner, UserSearchInput, useToast } from "~/components";
+import { BasicUserInfo } from "~/bindings/BasicUserInfo";
+import { UpdateUserRolesInWorkspaceRequest } from "~/bindings/UpdateUserRolesInWorkspaceRequest";
+import { WithId } from "~/bindings/WithId";
+import { useLastWorkspaceId } from "~/hooks/state-hooks";
+import { useMembersQuery, useRoleUsersQuery } from "~/hooks/fetch";
+import { memberKeys, roleKeys } from "~/hooks/query-keys";
+import { httpRequest } from "~/utils/http-request";
+import { Color } from "~/utils/color";
+
+interface RoleUsersChipsProps {
+	roleId: string;
+}
+
+const RoleUsersChips = (props: RoleUsersChipsProps) => {
+	const [workspaceId] = useLastWorkspaceId();
+	const queryClient = useQueryClient();
+	const toast = useToast();
+
+	const usersQuery = useRoleUsersQuery(() => props.roleId);
+	// Unpaginated fetch so we can read any target user's current role set
+	// before mutating it (the backend has no "add/remove single role" endpoint —
+	// only a full replace on POST /rbac/user/:userId).
+	// TODO: replace with a dedicated single-role add/remove endpoint once the
+	// backend exposes one — pulling every member + N user details per expansion
+	// doesn't scale.
+	const membersQuery = useMembersQuery(
+		() => undefined,
+		() => undefined
+	);
+
+	const [pickedUser, setPickedUser] = createSignal<WithId<BasicUserInfo> | null>(null);
+	const [isMutating, setIsMutating] = createSignal(false);
+
+	const getCurrentRoleIds = (userId: string): string[] => {
+		const member = membersQuery.data?.members.find((m) => m.userId === userId);
+		return member?.roleIds ?? [];
+	};
+
+	const updateUserRoles = async (userId: string, roleIds: string[]): Promise<boolean> => {
+		const wsId = workspaceId();
+		if (!wsId) {
+			toast("Workspace ID is missing", "error");
+			return false;
+		}
+		const body: UpdateUserRolesInWorkspaceRequest = { roles: roleIds };
+		const response = await httpRequest(
+			`${import.meta.env.VITE_BASE_URL}/api/workspace/${wsId}/rbac/user/${userId}`,
+			{ method: "POST", body: JSON.stringify(body) }
+		);
+		if (!response.ok) {
+			toast(response.data.error || "Failed to update user roles", "error");
+			return false;
+		}
+		queryClient.invalidateQueries({ queryKey: roleKeys.users(wsId, props.roleId) });
+		queryClient.invalidateQueries({ queryKey: memberKeys.all(wsId) });
+		return true;
+	};
+
+	const removeUser = async (userId: string, username: string) => {
+		if (isMutating() || !membersQuery.data) {
+			if (!membersQuery.data) toast("Members not loaded yet, try again", "error");
+			return;
+		}
+		setIsMutating(true);
+		const next = getCurrentRoleIds(userId).filter((id) => id !== props.roleId);
+		const ok = await updateUserRoles(userId, next);
+		setIsMutating(false);
+		if (ok) toast(`Removed ${username} from role`, "success");
+	};
+
+	const addUser = async () => {
+		const user = pickedUser();
+		if (!user || isMutating() || !membersQuery.data) {
+			if (user && !membersQuery.data) toast("Members not loaded yet, try again", "error");
+			return;
+		}
+		setIsMutating(true);
+		const current = getCurrentRoleIds(user.id);
+		if (current.includes(props.roleId)) {
+			toast(`${user.username} already has this role`, "info");
+			setIsMutating(false);
+			return;
+		}
+		const ok = await updateUserRoles(user.id, [...current, props.roleId]);
+		setIsMutating(false);
+		if (ok) {
+			toast(`Added ${user.username} to role`, "success");
+			setPickedUser(null);
+		}
+	};
+
+	const canMutate = () => !isMutating() && !!membersQuery.data;
+
+	return (
+		<div class="flex flex-col gap-3">
+			{/* Chips */}
+			<Show
+				when={!usersQuery.isPending}
+				fallback={
+					<div class="flex items-center gap-2 text-grey text-xs">
+						<LoadingSpinner size={14} />
+						<span>Loading users...</span>
+					</div>
+				}
+			>
+				<Show
+					when={(usersQuery.data ?? []).length > 0}
+					fallback={<span class="text-grey text-xs italic">No users assigned</span>}
+				>
+					<div class="flex flex-wrap gap-2">
+						<For each={usersQuery.data ?? []}>
+							{(user) => (
+								<div class="flex items-center gap-1.5 bg-secondary rounded-full pl-1 pr-1 py-0.5 text-xs text-white">
+									<Initials bgColor={Color.Secondary} firstName={user.firstName} lastName={user.lastName} size="xs" />
+									<span class="font-mono truncate max-w-40">{user.username}</span>
+									<button
+										type="button"
+										aria-label={`Remove ${user.username} from role`}
+										onClick={() => removeUser(user.id, user.username).catch(() => { })}
+										disabled={!canMutate()}
+										class="text-grey hover:text-error transition-colors p-0.5 rounded-full cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+									>
+										<FiX size={12} />
+									</button>
+								</div>
+							)}
+						</For>
+					</div>
+				</Show>
+			</Show>
+
+			{/* Add user form */}
+			<div class="flex flex-col md:flex-row gap-2 pt-3 border-t border-border-color/40">
+				<UserSearchInput
+					class="flex-1"
+					placeholder="Add user to this role..."
+					onUserSelect={(u) => setPickedUser(u)}
+				/>
+				<Button
+					variant={ButtonVariant.Outlined}
+					onClick={() => addUser().catch(() => { })}
+					disabled={!pickedUser() || !canMutate()}
+					loading={isMutating()}
+					class="flex items-center gap-2"
+				>
+					<FiUserPlus size={14} />
+					Add user
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default RoleUsersChips;

--- a/frontend/src/routes/_logged-in/_workspaced/workspace/roles/index.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/workspace/roles/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/solid-router";
 import { Title } from "@solidjs/meta";
 import { createEffect, createSignal, Show, Suspense } from "solid-js";
-import { FiTrash2 } from "solid-icons/fi";
+import { FiChevronDown, FiChevronUp, FiTrash2 } from "solid-icons/fi";
 
 import {
 	Button,
@@ -16,6 +16,7 @@ import {
 	Table,
 	useToast,
 } from "~/components";
+import RoleUsersChips from "./-components/role-users-chips";
 import { Color } from "~/utils/color";
 import { useNavigate } from "@tanstack/solid-router";
 import { useAuthState, createPaginationState, useIsAllowed } from "~/hooks";
@@ -32,6 +33,7 @@ const RoleRow = (props: { role: WithId<Role>; onDeleted: () => void }) => {
 	const [workspaceId] = useLastWorkspaceId();
 	const toast = useToast();
 	const [deleteOpen, setDeleteOpen] = createSignal(false);
+	const [expanded, setExpanded] = createSignal(false);
 
 	const onClickDelete = async () => {
 		const auth = authState();
@@ -63,49 +65,72 @@ const RoleRow = (props: { role: WithId<Role>; onDeleted: () => void }) => {
 	};
 
 	return (
-		<tr role="row" class="table-row">
-			<td role="cell" class="flex-3 flex items-center justify-start min-w-0">
-				<span class="truncate font-medium text-white">{props.role.name}</span>
+		<tr
+			role="row"
+			class="flex flex-col w-full border border-border-color bg-secondary-light last-of-type:rounded-b-xs hover:bg-secondary-medium"
+		>
+			{/* Inner flex ratios below must stay in sync with the parent Table's column_grids. */}
+			<td role="cell" class="flex items-center justify-center min-h-10 w-full px-md md:px-xl">
+				<div class="flex-3 flex items-center justify-start min-w-0">
+					<span class="truncate font-medium text-white">{props.role.name}</span>
+				</div>
+				<div class="flex-5 flex items-center justify-start min-w-0">
+					<span class={props.role.description ? "truncate" : "truncate text-grey italic"}>
+						{props.role.description || "No description"}
+					</span>
+				</div>
+				<div class="flex-2 flex items-center justify-center min-w-0">
+					<Link
+						href={`/workspace/roles/${props.role.id}`}
+						buttonVariant={ButtonVariant.Plain}
+						class="h-full flex items-center gap-2 cursor-pointer"
+					>
+						Manage Role
+					</Link>
+				</div>
+				<div class="flex-2 flex items-center justify-center min-w-0">
+					<Button
+						variant={ButtonVariant.Plain}
+						aria-label={expanded() ? "Hide users" : "See users"}
+						aria-expanded={expanded()}
+						onClick={() => setExpanded(!expanded())}
+						class="flex items-center gap-1 cursor-pointer"
+					>
+						<span>{expanded() ? "Hide users" : "See users"}</span>
+						{expanded() ? <FiChevronUp size={14} /> : <FiChevronDown size={14} />}
+					</Button>
+				</div>
+				<div class="flex-1 flex items-center justify-center min-w-0">
+					<DeleteModal
+						title={`Delete Role "${props.role.name}"`}
+						resourceName={props.role.name}
+						onClickDelete={onClickDelete}
+						isOpen={deleteOpen}
+						setIsOpen={setDeleteOpen}
+						renderTrigger={(open) => {
+							return (
+								<Button
+									variant={ButtonVariant.Plain}
+									color={Color.Error}
+									aria-label="Delete role"
+									onClick={(e) => {
+										e.stopPropagation();
+										open?.(true);
+									}}
+									class="p-1"
+								>
+									<FiTrash2 size={16} />
+								</Button>
+							);
+						}}
+					/>
+				</div>
 			</td>
-			<td role="cell" class="flex-5 flex items-center justify-start min-w-0">
-				<span class={props.role.description ? "truncate" : "truncate text-grey italic"}>
-					{props.role.description || "No description"}
-				</span>
-			</td>
-			<td role="cell" class="flex-3 flex items-center justify-center min-w-0">
-				<Link
-					href={`/workspace/roles/${props.role.id}`}
-					buttonVariant={ButtonVariant.Plain}
-					class="h-full flex items-center gap-2 cursor-pointer"
-				>
-					Manage Role
-				</Link>
-			</td>
-			<td role="cell" class="flex-1 flex items-center justify-center min-w-0">
-				<DeleteModal
-					title={`Delete Role "${props.role.name}"`}
-					resourceName={props.role.name}
-					onClickDelete={onClickDelete}
-					isOpen={deleteOpen}
-					setIsOpen={setDeleteOpen}
-					renderTrigger={(open) => {
-						return (
-							<Button
-								variant={ButtonVariant.Plain}
-								color={Color.Error}
-								aria-label="Delete role"
-								onClick={(e) => {
-									e.stopPropagation();
-									open?.(true);
-								}}
-								class="p-1"
-							>
-								<FiTrash2 size={16} />
-							</Button>
-						);
-					}}
-				/>
-			</td>
+			<Show when={expanded()}>
+				<td role="cell" class="w-full px-md md:px-xl py-sm border-t border-border-color/40">
+					<RoleUsersChips roleId={props.role.id} />
+				</td>
+			</Show>
 		</tr>
 	);
 };
@@ -178,8 +203,8 @@ const ManageRoles = () => {
 							}
 						>
 							<Table
-								column_grids={["flex-3", "flex-5", "flex-3", "flex-1"]}
-								headings={["Role Name", "Description", "Actions", ""]}
+								column_grids={["flex-3", "flex-5", "flex-2", "flex-2", "flex-1"]}
+								headings={["Role Name", "Description", "Actions", "", ""]}
 								rows={rolesQuery.data?.roles || []}
 								renderRow={(role) => <RoleRow role={role} onDeleted={refetchRoles} />}
 							/>


### PR DESCRIPTION
## Summary
- New **RoleUsersChips** component lets you view, add, and remove users on a role inline from the roles table (row expand). Guarded so we never POST a role-replace before the members list has loaded — avoids accidentally wiping a user's other roles.
- `Initials` gains an optional `bgColor` prop so chips can theme the avatar bubble.
- Log terminal polish: drop the line-number gutter, add a **Download logs** button that exports the current buffer as `.log`.
- Drop the `sessionStorage` permissions cache in `useUserPermissionsQuery` — TanStack Query's `gcTime` already covers this and the shim could go stale across nav.
- Ignore `*.db-journal` (SQLite WAL companion).

## Notes
- Backend has no single-role add/remove endpoint, so the chip add/remove flow does a full role-set replace on `POST /rbac/user/:userId`. TODO comment in the component points at the eventual fix.
- Inner flex ratios in the new role row must stay in sync with the parent `Table`'s `column_grids`; comment added.

## Test plan
- [ ] Roles list renders, "See users" expands and shows current users on the role
- [ ] Adding a user via the search input attaches the role without losing their other roles
- [ ] Removing a user via the chip X removes only that role
- [ ] If members fetch fails, add/remove buttons stay disabled and a toast surfaces
- [ ] Log terminal: line numbers gone; **Download logs** produces a `.log` with `ts<TAB>message` per line
- [ ] First load after sign-in: permissions resolve and gated UI doesn't get stuck in a "no access" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)