### PR TITLE
Add a password strength indicator on sign-up, reset password and change password.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,8 @@
 		"@tanstack/router-plugin": "^1.167.35",
 		"@tanstack/solid-query": "^5.100.10",
 		"@tanstack/solid-router": "^1.169.2",
+		"@zxcvbn-ts/core": "^4.1.2",
+		"@zxcvbn-ts/language-common": "^4.1.2",
 		"chart.js": "^4.5.1",
 		"js-cookie": "^3.0.5",
 		"p-limit": "^7.3.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -32,6 +32,12 @@ importers:
       '@tanstack/solid-router':
         specifier: ^1.169.2
         version: 1.169.2(solid-js@1.9.12)
+      '@zxcvbn-ts/core':
+        specifier: ^4.1.2
+        version: 4.1.2
+      '@zxcvbn-ts/language-common':
+        specifier: ^4.1.2
+        version: 4.1.2
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
@@ -1382,6 +1388,15 @@ packages:
     peerDependencies:
       vinxi: ^0.5.5
 
+  '@zxcvbn-ts/core@4.1.2':
+    resolution: {integrity: sha512-RQmxWB3AMI+HGQErQdUv6Aq32aQhp6xOxrfgCP0+T9MsLZoP3xtLHuT8O8VojsUxdmQVZfJlYkYb1A0wOwIS+Q==}
+
+  '@zxcvbn-ts/dictionary-compression@3.0.1':
+    resolution: {integrity: sha512-p3KyPzxGc3vWSap5hHA6SllbUCmh7s+NtpGyC3qEWrxYJT9t9TUAzjPm48Okipo+UUyPQfDlIvTcs9JRShBFiQ==}
+
+  '@zxcvbn-ts/language-common@4.1.2':
+    resolution: {integrity: sha512-uJlBzhC9/KjPImqdnc1/lPxmdn4xKbkruN5p1mASWkXA0gli+GZ5LrVL+dqscA8Pcf4OfudE56TtCWeHljJOvA==}
+
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -2056,6 +2071,10 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4812,6 +4831,16 @@ snapshots:
       recast: 0.23.11
       vinxi: 0.5.11(@types/node@24.12.3)(db0@0.3.4)(ioredis@5.10.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)
 
+  '@zxcvbn-ts/core@4.1.2':
+    dependencies:
+      fastest-levenshtein: 1.0.16
+
+  '@zxcvbn-ts/dictionary-compression@3.0.1': {}
+
+  '@zxcvbn-ts/language-common@4.1.2':
+    dependencies:
+      '@zxcvbn-ts/dictionary-compression': 3.0.1
+
   abbrev@3.0.1: {}
 
   abort-controller@3.0.0:
@@ -5480,6 +5509,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fastest-levenshtein@1.0.16: {}
 
   fastq@1.20.1:
     dependencies:

--- a/frontend/src/components/index.tsx
+++ b/frontend/src/components/index.tsx
@@ -45,6 +45,7 @@ import RangeSlider from "~/components/range-slider";
 import StatusChip from "~/components/status-chip";
 import OtpInput from "~/components/otp-input";
 import ChipInput from "~/components/chip-input";
+import PasswordStrength from "~/components/password-strength";
 import Sidebar from "~/components/sidebar";
 import TopBar from "~/components/top-bar";
 export {
@@ -96,6 +97,7 @@ export {
 	StatusChip,
 	OtpInput,
 	ChipInput,
+	PasswordStrength,
 	Sidebar,
 	TopBar,
 };

--- a/frontend/src/components/password-strength.tsx
+++ b/frontend/src/components/password-strength.tsx
@@ -1,0 +1,149 @@
+import { Accessor, createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import { FiCheck, FiX } from "solid-icons/fi";
+import { passwordStrength } from "~/utils/validation";
+import { loadEstimator } from "~/utils/password-estimator";
+
+interface PasswordStrengthProps {
+	/** Accessor for the current password value. */
+	password: Accessor<string>;
+	/** Accessor for the element the panel anchors to (the field wrapper). */
+	anchor: Accessor<HTMLElement | undefined>;
+	/** Accessor for whether the field is focused. */
+	show: Accessor<boolean>;
+}
+
+const SEGMENT_COUNT = 4;
+const PANEL_WIDTH = 260;
+const GAP = 12;
+const MD_BREAKPOINT = 768;
+
+interface Position {
+	placement: "right" | "above";
+	left: number;
+	width: number;
+	top?: number;
+	bottom?: number;
+}
+
+const bgForColor = (color: "error" | "warning" | "success") =>
+	color === "error" ? "bg-error" : color === "warning" ? "bg-warning" : "bg-success";
+
+const textForColor = (color: "error" | "warning" | "success") =>
+	color === "error" ? "text-error" : color === "warning" ? "text-warning" : "text-success";
+
+/**
+ * A floating panel anchored to a password field showing a stepped strength
+ * meter and a live requirements checklist. Placed to the right of the field on
+ * viewports >= md, above it on narrow viewports. Shown while the field is
+ * focused and non-empty. Purely informational — rendered via a Portal with
+ * pointer-events disabled so it never intercepts clicks.
+ */
+const PasswordStrength = (props: PasswordStrengthProps) => {
+	const visible = () => props.show() && props.password().length > 0;
+
+	// zxcvbn scorer, lazy-loaded on first use. Until it resolves, `strength`
+	// falls back to the length heuristic inside `passwordStrength`.
+	const [scorer, setScorer] = createSignal<(password: string) => number>();
+	const strength = createMemo(() => {
+		const score = scorer()?.(props.password());
+		return passwordStrength(props.password(), score);
+	});
+
+	const [position, setPosition] = createSignal<Position>();
+
+	const updatePosition = () => {
+		const el = props.anchor();
+		if (!el || typeof window === "undefined") return;
+		const rect = el.getBoundingClientRect();
+		const wideEnough = window.innerWidth >= MD_BREAKPOINT;
+		const roomOnRight = rect.right + GAP + PANEL_WIDTH <= window.innerWidth;
+		if (wideEnough && roomOnRight) {
+			setPosition({ placement: "right", left: rect.right + GAP, top: rect.top, width: PANEL_WIDTH });
+		} else {
+			setPosition({
+				placement: "above",
+				left: rect.left,
+				bottom: window.innerHeight - rect.top + GAP,
+				width: rect.width,
+			});
+		}
+	};
+
+	createEffect(() => {
+		if (!visible()) return;
+		// Kick off the zxcvbn load the first time the panel is shown; idempotent.
+		if (!scorer()) void loadEstimator().then((fn) => setScorer(() => fn));
+		updatePosition();
+		const onMove = () => updatePosition();
+		window.addEventListener("scroll", onMove, true);
+		window.addEventListener("resize", onMove);
+		onCleanup(() => {
+			window.removeEventListener("scroll", onMove, true);
+			window.removeEventListener("resize", onMove);
+		});
+	});
+
+	const panelStyle = () => {
+		const p = position();
+		if (!p) return {};
+		return {
+			position: "fixed" as const,
+			left: `${p.left}px`,
+			width: `${p.width}px`,
+			...(p.placement === "right" ? { top: `${p.top}px` } : { bottom: `${p.bottom}px` }),
+		};
+	};
+
+	const tierLabel = () => {
+		const t = strength().tier;
+		return t.charAt(0).toUpperCase() + t.slice(1);
+	};
+
+	return (
+		<Show when={visible() && position()}>
+			<Portal>
+				<div
+					style={panelStyle()}
+					class="z-50 pointer-events-none p-4 bg-secondary-light border border-white/10 rounded-lg shadow-lg"
+				>
+					<div class="flex items-center justify-between mb-2">
+						<span class="text-xxs text-grey uppercase tracking-wide">Password strength</span>
+						<span class={`text-xs font-medium ${textForColor(strength().color)}`}>{tierLabel()}</span>
+					</div>
+					<div class="flex gap-1 mb-3">
+						<For each={Array.from({ length: SEGMENT_COUNT })}>
+							{(_, index) => (
+								<div
+									class={`h-1 flex-1 rounded-full ${
+										index() < strength().segments
+											? bgForColor(strength().color)
+											: "bg-secondary-medium"
+									}`}
+								/>
+							)}
+						</For>
+					</div>
+					<ul class="flex flex-col gap-1">
+						<For each={strength().requirements}>
+							{(req) => (
+								<li
+									class={`flex items-center gap-2 text-xxs ${req.met ? "text-success" : "text-grey"}`}
+								>
+									{req.met ? (
+										<FiCheck size={12} class="text-success" />
+									) : (
+										<FiX size={12} class="text-grey" />
+									)}
+									<span>{req.label}</span>
+								</li>
+							)}
+						</For>
+					</ul>
+				</div>
+			</Portal>
+		</Show>
+	);
+};
+
+export default PasswordStrength;

--- a/frontend/src/routes/_logged-in/_workspaced/profile/-components/change-password.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/profile/-components/change-password.tsx
@@ -1,9 +1,19 @@
 import { createSignal, Show } from "solid-js";
-import { Alert, Button, ButtonVariant, InputWithLabel, OtpInput, PasswordInput, useToast } from "~/components";
+import {
+	Alert,
+	Button,
+	ButtonVariant,
+	InputWithLabel,
+	OtpInput,
+	PasswordInput,
+	PasswordStrength,
+	useToast,
+} from "~/components";
 import { EventT } from "~/utils/types";
 import { ChangePasswordRequest, ChangePasswordResponse } from "~/bindings";
 import { useAuthState } from "~/hooks";
 import { httpRequest } from "~/utils/http-request";
+import { validatePassword } from "~/utils/validation";
 
 const ChangePasswordSection = () => {
 	const [authState] = useAuthState();
@@ -15,6 +25,9 @@ const ChangePasswordSection = () => {
 
 	const [showMfa, setShowMfa] = createSignal(false);
 	const [mfaOtp, setMfaOtp] = createSignal("");
+
+	const [showPasswordStrength, setShowPasswordStrength] = createSignal(false);
+	const [passwordAnchor, setPasswordAnchor] = createSignal<HTMLDivElement>();
 
 	const [inputError, setInputError] = createSignal({
 		oldPassword: "",
@@ -30,6 +43,12 @@ const ChangePasswordSection = () => {
 		const auth = authState();
 		if (!auth || auth.type !== "LoggedIn") {
 			toast("You must be logged in to update your password", "error");
+			return;
+		}
+
+		const pwdCheck = validatePassword(newPassword());
+		if (!pwdCheck.valid) {
+			setInputError((prev) => ({ ...prev, newPassword: pwdCheck.error ?? "Invalid password" }));
 			return;
 		}
 
@@ -110,12 +129,28 @@ const ChangePasswordSection = () => {
 					</InputWithLabel>
 
 					<InputWithLabel for="new-password" label="New Password">
-						<div>
+						<div
+							ref={setPasswordAnchor}
+							onFocusIn={() => setShowPasswordStrength(true)}
+							onFocusOut={(e) => {
+								if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+									setShowPasswordStrength(false);
+								}
+							}}
+						>
 							<PasswordInput
 								value={newPassword()}
 								name="new-password"
 								placeholder="New Password"
-								onInput={(e) => setNewPassword(e.currentTarget.value)}
+								onInput={(e) => {
+									setNewPassword(e.currentTarget.value);
+									setInputError((prev) => ({ ...prev, newPassword: "" }));
+								}}
+							/>
+							<PasswordStrength
+								password={newPassword}
+								anchor={passwordAnchor}
+								show={showPasswordStrength}
 							/>
 							<Show when={inputError().newPassword}>
 								<div class="flex justify-start items-center mt-1">

--- a/frontend/src/routes/_logged-out/reset-password.tsx
+++ b/frontend/src/routes/_logged-out/reset-password.tsx
@@ -9,6 +9,7 @@ import {
 	Input,
 	InputType,
 	OtpInput,
+	PasswordInput,
 	PasswordStrength,
 	Turnstile,
 	useToast,
@@ -160,8 +161,7 @@ const ResetPassword = () => {
 						}
 					}}
 				>
-					<Input
-						type={InputType.Password}
+					<PasswordInput
 						placeholder="New password"
 						autocomplete="new-password"
 						required={true}
@@ -182,8 +182,7 @@ const ResetPassword = () => {
 					</div>
 				</Show>
 
-				<Input
-					type={InputType.Password}
+				<PasswordInput
 					placeholder="Confirm new password"
 					autocomplete="new-password"
 					required={true}

--- a/frontend/src/routes/_logged-out/reset-password.tsx
+++ b/frontend/src/routes/_logged-out/reset-password.tsx
@@ -2,7 +2,17 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/solid-router";
 import { Title } from "@solidjs/meta";
 import { createSignal, onMount, Show } from "solid-js";
 import { ResetPasswordRequest } from "~/bindings";
-import { Alert, Button, ButtonVariant, Input, InputType, OtpInput, Turnstile, useToast } from "~/components";
+import {
+	Alert,
+	Button,
+	ButtonVariant,
+	Input,
+	InputType,
+	OtpInput,
+	PasswordStrength,
+	Turnstile,
+	useToast,
+} from "~/components";
 import { createAsyncAction } from "~/hooks";
 import { httpRequest } from "~/utils/http-request";
 import { validatePassword } from "~/utils/validation";
@@ -27,6 +37,9 @@ const ResetPassword = () => {
 	const [confirmPassword, setConfirmPassword] = createSignal("");
 	const [confirmPasswordError, setConfirmPasswordError] = createSignal("");
 	const [turnstileToken, setTurnstileToken] = createSignal<string>("");
+
+	const [showPasswordStrength, setShowPasswordStrength] = createSignal(false);
+	const [passwordAnchor, setPasswordAnchor] = createSignal<HTMLDivElement>();
 
 	// Strip query params after reading them so the OTP doesn't linger in the URL.
 	onMount(() => {
@@ -137,21 +150,32 @@ const ResetPassword = () => {
 					<OtpInput inputVariant="medium" otpDigits={otpDigits} setOtpDigits={setOtpDigits} />
 				</div>
 
-				<Input
-					type={InputType.Password}
-					placeholder="New password"
-					autocomplete="new-password"
-					required={true}
-					name="new-password"
-					id="new-password"
-					value={newPassword}
-					onInput={(e) => {
-						setNewPassword((e.currentTarget as HTMLInputElement).value);
-						setNewPasswordError("");
-					}}
+				<div
+					ref={setPasswordAnchor}
 					class="mt-6"
-					styleVariant="medium"
-				/>
+					onFocusIn={() => setShowPasswordStrength(true)}
+					onFocusOut={(e) => {
+						if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+							setShowPasswordStrength(false);
+						}
+					}}
+				>
+					<Input
+						type={InputType.Password}
+						placeholder="New password"
+						autocomplete="new-password"
+						required={true}
+						name="new-password"
+						id="new-password"
+						value={newPassword}
+						onInput={(e) => {
+							setNewPassword((e.currentTarget as HTMLInputElement).value);
+							setNewPasswordError("");
+						}}
+						styleVariant="medium"
+					/>
+				</div>
+				<PasswordStrength password={newPassword} anchor={passwordAnchor} show={showPasswordStrength} />
 				<Show when={newPasswordError()}>
 					<div class="mt-1">
 						<Alert message={newPasswordError()} type="error" />

--- a/frontend/src/routes/_logged-out/sign-up.tsx
+++ b/frontend/src/routes/_logged-out/sign-up.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/solid-router";
 import { Title } from "@solidjs/meta";
 import { createSignal, Show } from "solid-js";
 import { CreateAccountRequest, SocialLoginInitiateResponse } from "~/bindings";
-import { Alert, Button, Input, InputType, PasswordStrength, useToast, Turnstile } from "~/components";
+import { Alert, Button, Input, InputType, PasswordInput, PasswordStrength, useToast, Turnstile } from "~/components";
 import { createAsyncAction } from "~/hooks";
 import { ButtonVariant } from "~/utils/color";
 import { httpRequest } from "~/utils/http-request";
@@ -274,8 +274,7 @@ const SignUp = () => {
 							}
 						}}
 					>
-						<Input
-							type={InputType.Password}
+						<PasswordInput
 							placeholder="Password"
 							autocomplete="new-password"
 							required={true}
@@ -296,8 +295,7 @@ const SignUp = () => {
 						</div>
 					</Show>
 
-					<Input
-						type={InputType.Password}
+					<PasswordInput
 						placeholder="Confirm Password"
 						autocomplete="new-password"
 						required={true}

--- a/frontend/src/routes/_logged-out/sign-up.tsx
+++ b/frontend/src/routes/_logged-out/sign-up.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/solid-router";
 import { Title } from "@solidjs/meta";
 import { createSignal, Show } from "solid-js";
 import { CreateAccountRequest, SocialLoginInitiateResponse } from "~/bindings";
-import { Alert, Button, Input, InputType, useToast, Turnstile } from "~/components";
+import { Alert, Button, Input, InputType, PasswordStrength, useToast, Turnstile } from "~/components";
 import { createAsyncAction } from "~/hooks";
 import { ButtonVariant } from "~/utils/color";
 import { httpRequest } from "~/utils/http-request";
@@ -60,6 +60,9 @@ const SignUp = () => {
 
 	const [turnstileToken, setTurnstileToken] = createSignal<string>("");
 	const [errors, setErrors] = createSignal<FieldErrors>({ ...emptyErrors });
+
+	const [showPasswordStrength, setShowPasswordStrength] = createSignal(false);
+	const [passwordAnchor, setPasswordAnchor] = createSignal<HTMLDivElement>();
 
 	const clearError = (field: keyof FieldErrors) => {
 		setErrors((prev) => ({ ...prev, [field]: "" }));
@@ -261,21 +264,32 @@ const SignUp = () => {
 						</div>
 					</Show>
 
-					<Input
-						type={InputType.Password}
-						placeholder="Password"
-						autocomplete="new-password"
-						required={true}
-						name="password"
-						id="password"
-						value={password}
-						onInput={(e) => {
-							setPassword(e.currentTarget.value);
-							clearError("password");
-						}}
+					<div
+						ref={setPasswordAnchor}
 						class="mt-4"
-						styleVariant="medium"
-					/>
+						onFocusIn={() => setShowPasswordStrength(true)}
+						onFocusOut={(e) => {
+							if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+								setShowPasswordStrength(false);
+							}
+						}}
+					>
+						<Input
+							type={InputType.Password}
+							placeholder="Password"
+							autocomplete="new-password"
+							required={true}
+							name="password"
+							id="password"
+							value={password}
+							onInput={(e) => {
+								setPassword(e.currentTarget.value);
+								clearError("password");
+							}}
+							styleVariant="medium"
+						/>
+					</div>
+					<PasswordStrength password={password} anchor={passwordAnchor} show={showPasswordStrength} />
 					<Show when={errors().password}>
 						<div class="mt-1">
 							<Alert message={errors().password} type="error" />

--- a/frontend/src/utils/password-estimator.ts
+++ b/frontend/src/utils/password-estimator.ts
@@ -1,0 +1,39 @@
+// Lazy loader for the zxcvbn password-strength estimator. The core library is
+// small, but its dictionary (@zxcvbn-ts/language-common) is large (~200KB gzip),
+// so both are pulled in via dynamic import() and only when first needed (when
+// the user starts typing a password). This keeps them out of the initial
+// bundle — nothing imports this module statically except the on-focus caller.
+
+type ScoreFn = (password: string) => number;
+
+let scoreFn: ScoreFn | undefined;
+let loading: Promise<ScoreFn> | undefined;
+
+/** The loaded scorer, or `undefined` if it hasn't finished loading yet. */
+export function getEstimator(): ScoreFn | undefined {
+	return scoreFn;
+}
+
+/**
+ * Loads (once) and returns the zxcvbn scorer. Safe to call repeatedly — the
+ * dynamic import and factory construction happen a single time; subsequent
+ * calls resolve to the cached function. Resolves to a function returning a 0–4
+ * strength score for a password. No-op safety: only invoke from client code
+ * (it dynamically imports browser-oriented packages).
+ */
+export function loadEstimator(): Promise<ScoreFn> {
+	if (scoreFn) return Promise.resolve(scoreFn);
+	if (loading) return loading;
+
+	loading = (async () => {
+		const [core, common] = await Promise.all([import("@zxcvbn-ts/core"), import("@zxcvbn-ts/language-common")]);
+		const zxcvbn = new core.ZxcvbnFactory({
+			dictionary: { ...common.dictionary },
+			graphs: common.adjacencyGraphs,
+		});
+		scoreFn = (password: string) => zxcvbn.check(password).score;
+		return scoreFn;
+	})();
+
+	return loading;
+}

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -24,6 +24,36 @@ const USERNAME_VALIDITY_PATTERN = "[a-z0-9_][a-z0-9_\\.\\-]*[a-z0-9_]";
 // best-effort client gate.
 const USERNAME_OR_EMAIL_PATTERN = "([a-z0-9_][a-z0-9_\\.\\-]*[a-z0-9_]|[^@\\s]+@[^@\\s]+\\.[^@\\s]+)";
 
+// Special characters accepted in passwords. Mirrors the backend
+// `validate_password` set. Shared between `validatePassword` and
+// `passwordStrength` so the two never drift.
+const PASSWORD_SPECIAL_CHARS = new Set([
+	"@",
+	"!",
+	"#",
+	"$",
+	"%",
+	"^",
+	"&",
+	"*",
+	"?",
+	"/",
+	"\\",
+	"|",
+	"~",
+	"`",
+	".",
+	",",
+	";",
+	":",
+	"<",
+	">",
+	"[",
+	"]",
+	"{",
+	"}",
+]);
+
 /**
  * Validates if a password meets the following requirements:
  * - A minimum of 8 characters
@@ -39,33 +69,6 @@ export function validatePassword(value: string): {
 	valid: boolean;
 	error?: string;
 } {
-	const specialChars = new Set([
-		"@",
-		"!",
-		"#",
-		"$",
-		"%",
-		"^",
-		"&",
-		"*",
-		"?",
-		"/",
-		"\\",
-		"|",
-		"~",
-		"`",
-		".",
-		",",
-		";",
-		":",
-		"<",
-		">",
-		"[",
-		"]",
-		"{",
-		"}",
-	]);
-
 	let hasDigit = false;
 	let hasUppercase = false;
 	let hasLowercase = false;
@@ -75,7 +78,7 @@ export function validatePassword(value: string): {
 		if (/\d/.test(char)) hasDigit = true;
 		if (/[A-Z]/.test(char)) hasUppercase = true;
 		if (/[a-z]/.test(char)) hasLowercase = true;
-		if (specialChars.has(char)) hasSpecial = true;
+		if (PASSWORD_SPECIAL_CHARS.has(char)) hasSpecial = true;
 	}
 
 	if (!hasDigit) {
@@ -104,6 +107,85 @@ export function validatePassword(value: string): {
 	}
 
 	return { valid: true };
+}
+
+export interface PasswordRequirement {
+	label: string;
+	met: boolean;
+}
+
+export interface PasswordStrengthResult {
+	/** Overall tier. `weak` = fails `validatePassword`. */
+	tier: "weak" | "fair" | "good" | "strong";
+	/** Number of the 4 meter segments that should be filled. */
+	segments: number;
+	/** Theme color token for the tier. */
+	color: "error" | "warning" | "success";
+	/** Per-rule met/unmet state for the checklist. */
+	requirements: PasswordRequirement[];
+}
+
+/**
+ * Grades a password for the strength indicator. The tier is anchored to
+ * `validatePassword`: anything that fails it is `weak`. Beyond that:
+ *
+ * - When a zxcvbn `score` (0–4) is supplied, it drives the tier: 0–1 = fair,
+ *   2–3 = good, 4 = strong. This catches guessable-but-well-formed passwords
+ *   (e.g. `Password@123`) that a length check alone would rate "strong".
+ * - When `score` is omitted (the estimator hasn't lazy-loaded yet), it falls
+ *   back to a length heuristic (< 12 = good, >= 12 = strong) so the meter still
+ *   works on the first keystrokes.
+ *
+ * In both paths a password shorter than 8 characters is capped at `fair`, since
+ * the backend rejects it for length regardless of composition.
+ *
+ * The requirements list surfaces every individual rule (including the 8-char
+ * minimum, which `validatePassword` itself does not check).
+ */
+export function passwordStrength(value: string, score?: number): PasswordStrengthResult {
+	let hasDigit = false;
+	let hasUppercase = false;
+	let hasLowercase = false;
+	let hasSpecial = false;
+
+	for (const char of value) {
+		if (/\d/.test(char)) hasDigit = true;
+		if (/[A-Z]/.test(char)) hasUppercase = true;
+		if (/[a-z]/.test(char)) hasLowercase = true;
+		if (PASSWORD_SPECIAL_CHARS.has(char)) hasSpecial = true;
+	}
+
+	const requirements: PasswordRequirement[] = [
+		{ label: "At least 8 characters", met: value.length >= 8 },
+		{ label: "One uppercase letter", met: hasUppercase },
+		{ label: "One lowercase letter", met: hasLowercase },
+		{ label: "One number", met: hasDigit },
+		{ label: "One special character", met: hasSpecial },
+	];
+
+	if (!validatePassword(value).valid) {
+		return { tier: "weak", segments: 1, color: "error", requirements };
+	}
+	// Never advertise more than "fair" for a password the backend rejects for length.
+	if (value.length < 8) {
+		return { tier: "fair", segments: 2, color: "warning", requirements };
+	}
+
+	if (score !== undefined) {
+		if (score <= 1) {
+			return { tier: "fair", segments: 2, color: "warning", requirements };
+		}
+		if (score <= 3) {
+			return { tier: "good", segments: 3, color: "warning", requirements };
+		}
+		return { tier: "strong", segments: 4, color: "success", requirements };
+	}
+
+	// Estimator not loaded yet — length-based fallback.
+	if (value.length < 12) {
+		return { tier: "good", segments: 3, color: "warning", requirements };
+	}
+	return { tier: "strong", segments: 4, color: "success", requirements };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Password strength meter on sign-up, reset-password, and change-password: a stepped 4-segment meter + requirements checklist, shown on focus. Anything failing our existing validatePassword() constraints is Weak; the rest is tiered by a lazily-loaded zxcvbn score (fixes Password@123 being rated "Strong").
- Reveal toggle on sign-up and reset-password — those four fields used a raw <Input type={Password}>; switched them to the existing PasswordInput component, which change-password already used.

## Test plan
- Ran zxcvbn against the tiering logic: weakpass → Weak (fails constraints), Password1! → Fair, Password@123 → Good, Tr0ub4dour&3xyz → Strong.
- tsc --noEmit, eslint, prettier --check clean on the changed files.
- Meter placement (right of field ≥768px, above below) and the reveal toggle still need a browser click-through — I verified those from the code, not in-browser.

---

By opening this pull request, I confirm that I have read and agreed to the terms in [CONTRIBUTING.md](../CONTRIBUTING.md), and that I am legally allowed to submit this code under those terms.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/patr-cloud/codesmith/patr/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786509041&installation_id=145740543&pr_number=258&repository=patr-cloud%2Fpatr&return_to=https%3A%2F%2Fgithub.com%2Fpatr-cloud%2Fpatr%2Fpull%2F258&signature=c22a497dacafd007acfddd9fd5c3e4df7ab71b1713e6762184941bcb6f3eb90a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->