### PR TITLE
Upload a .env file into the deployment env input

### DIFF
--- a/e2e/helpers/ui/deployment.ts
+++ b/e2e/helpers/ui/deployment.ts
@@ -100,6 +100,39 @@ export async function fillFirstEnv(page: Page, key: string, value: string): Prom
 	await page.locator('input[placeholder="Enter Env Value"]').first().fill(value);
 }
 
+// ---------- .env upload modal (env-upload-modal.tsx) ----------
+
+// Opens the review modal and hands it `contents` as a .env file. The file input
+// is hidden behind a dropzone, so set it directly; `name="env-file"` keeps this
+// off the config-mount FileInputs ("deployment-config") on the same page.
+export async function uploadEnvFile(page: Page, contents: string): Promise<void> {
+	await page.getByRole('button', { name: /Upload your \.env file/i }).click();
+	await page.locator('input[name="env-file"]').setInputFiles({
+		name: '.env',
+		mimeType: 'text/plain',
+		buffer: Buffer.from(contents),
+	});
+}
+
+// "Parsed N variables from .env" summary shown once a file is ingested.
+export function envUploadSummary(page: Page) {
+	return page.getByText(/Parsed\s+\d+\s+variables?\s+from/i);
+}
+
+// Key inputs of the parsed rows, in order ("KEY" placeholder). Assert contents
+// with toHaveValue: the value is a DOM property, not a matchable attribute.
+export function envUploadKeys(page: Page) {
+	return page.locator('input[placeholder="KEY"]');
+}
+
+export function addToDeploymentButton(page: Page) {
+	return page.getByRole('button', { name: /Add to deployment/i });
+}
+
+export async function submitEnvUpload(page: Page): Promise<void> {
+	await addToDeploymentButton(page).click();
+}
+
 // ---------- Detail (/deployments/{id}) ----------
 
 export async function openDeploymentDetail(page: Page, id: string, tab?: string): Promise<void> {

--- a/e2e/specs/deployment/create.spec.ts
+++ b/e2e/specs/deployment/create.spec.ts
@@ -21,6 +21,10 @@ import {
 	createDeploymentLink,
 	fillFirstPort,
 	fillFirstEnv,
+	uploadEnvFile,
+	envUploadSummary,
+	envUploadKeys,
+	submitEnvUpload,
 } from '@/helpers/ui/deployment';
 
 // Deployment creation through the dashboard. The API contract — registry/tag/
@@ -115,6 +119,57 @@ test.describe('deployment > create [UI]', () => {
 		const info = await getDeploymentInfoAPI(api, user, user.workspaceId, createdId);
 		expect(info.ports).toEqual({ '8080': 'http' });
 		expect(info.environmentVariables).toEqual({ FOO: 'bar' });
+	});
+
+	test('an uploaded .env file is parsed, reviewable, and persists on create', async ({
+		browser,
+		api,
+	}) => {
+		await using user = await createUserWithWorkspace(api);
+		const runner = await createRunnerAPI(api, user, user.workspaceId);
+		let createdId = '';
+		// Exercises the parser through the UI: a comment, an `export ` prefix, a
+		// double-quoted value with a space, and a duplicate key (last one wins).
+		const dotEnv = [
+			'# a comment',
+			'FOO=bar',
+			'export QUOTED="a b"',
+			'TRAILING=keep # inline comment',
+			'DUP=first',
+			'DUP=second',
+			'',
+		].join('\n');
+		await withCreatePage(browser, user, async (page) => {
+			await fillDeploymentName(page, randomDeploymentName());
+			await selectRegistry(page, 'Docker Hub');
+			await fillImageName(page, 'traefik/whoami');
+			await fillImageTag(page, 'latest');
+			await selectRunner(page, runner.name);
+
+			await uploadEnvFile(page, dotEnv);
+			// 4 keys, not 5: the comment is skipped and DUP is deduped.
+			await expect(envUploadSummary(page)).toContainText('4');
+			await expect(envUploadKeys(page).first()).toHaveValue('FOO');
+			await submitEnvUpload(page);
+
+			// The rows landed in the env editor behind the modal.
+			await expect(page.locator('input[placeholder="Enter Env Name"]').first()).toHaveValue(
+				'FOO',
+			);
+
+			await submitCreateDeployment(page);
+			await expectToast(page, /Deployment created successfully/i);
+			await expectUrl(page, /\/deployments\/[0-9a-f]{32}/, { timeout: 10_000 });
+			createdId = (page.url().match(/\/deployments\/([0-9a-f]{32})/) ?? [])[1] ?? '';
+		});
+		expect(createdId).toMatch(/^[0-9a-f]{32}$/);
+		const info = await getDeploymentInfoAPI(api, user, user.workspaceId, createdId);
+		expect(info.environmentVariables).toEqual({
+			FOO: 'bar',
+			QUOTED: 'a b',
+			TRAILING: 'keep',
+			DUP: 'second',
+		});
 	});
 
 	test('the header Create button appears once there is at least one deployment', async ({

--- a/frontend/src/routes/_logged-in/_workspaced/deployments/-components/env-input.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/deployments/-components/env-input.tsx
@@ -1,10 +1,11 @@
-import { FiTrash2 } from "solid-icons/fi";
+import { FiTrash2, FiUpload } from "solid-icons/fi";
 import { createEffect, createMemo, createSignal, createUniqueId, Index, Show } from "solid-js";
 import { EnvironmentVariableValue } from "~/bindings";
 import { Button, ButtonVariant, Input, InputType, Label } from "~/components";
 import { Color } from "~/utils/color";
 import { get } from "~/utils/func";
 import { MaybeAccessor } from "~/utils/types";
+import EnvUploadModal from "./env-upload-modal";
 
 interface EnvInputProps {
 	/** Current environment variables (source of truth). */
@@ -126,6 +127,45 @@ const EnvInput = (props: EnvInputProps) => {
 		});
 	};
 
+	const [uploadOpen, setUploadOpen] = createSignal(false);
+
+	// Committed keys the upload modal validates against: a key already bound to a
+	// secret must not be silently replaced with a plain value from a .env file.
+	const existingKeys = createMemo(() => {
+		const m = new Map<string, boolean>();
+		for (const row of rows()) {
+			if (row.key === "") continue;
+			m.set(row.key, isSecretValue(row.value));
+		}
+		return m;
+	});
+
+	const applyUploadedEnvs = (entries: Array<{ key: string; value: string }>) => {
+		const pending = new Map(entries.map((e) => [e.key, e.value] as const));
+		setRows((prev) => {
+			const next: Row[] = [];
+			for (const row of prev) {
+				if (row.key !== "" && pending.has(row.key)) {
+					next.push({ ...row, value: pending.get(row.key)! });
+					pending.delete(row.key);
+				} else {
+					next.push(row);
+				}
+			}
+			// Drop any trailing draft row before appending the new entries.
+			while (next.length > 0) {
+				const last = next[next.length - 1];
+				if (last.key === "" && valueIsEmpty(last.value)) next.pop();
+				else break;
+			}
+			for (const [key, value] of pending) {
+				next.push({ id: createUniqueId(), key, value });
+			}
+			next.push(makeDraftRow());
+			return next;
+		});
+	};
+
 	const handleBlur = (id: string) => {
 		setRows((prev) => {
 			const row = prev.find((r) => r.id === id);
@@ -142,7 +182,7 @@ const EnvInput = (props: EnvInputProps) => {
 		<div class={`flex gap-8 items-start w-full ${get(props.class) ?? ""}`}>
 			<Label parentClass="flex-2 pt-2.5" label="Environment Variables" />
 
-			<div class="flex flex-col flex-10 gap-4 w-full">
+			<div class="flex flex-col flex-10 gap-1 w-full">
 				<Index each={rows()}>
 					{(row) => {
 						const errs = () => rowError(row());
@@ -224,6 +264,24 @@ const EnvInput = (props: EnvInputProps) => {
 						);
 					}}
 				</Index>
+
+				<Show when={!get(props.disabled)}>
+					<Button
+						type="button"
+						variant={ButtonVariant.Plain}
+						onClick={() => setUploadOpen(true)}
+						class="self-start flex items-center gap-2 text-sm cursor-pointer"
+					>
+						<FiUpload size={14} />
+						Upload your .env file
+					</Button>
+					<EnvUploadModal
+						isOpen={uploadOpen}
+						setIsOpen={setUploadOpen}
+						existingKeys={existingKeys}
+						onSubmit={applyUploadedEnvs}
+					/>
+				</Show>
 			</div>
 		</div>
 	);

--- a/frontend/src/routes/_logged-in/_workspaced/deployments/-components/env-upload-modal.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/deployments/-components/env-upload-modal.tsx
@@ -1,0 +1,332 @@
+import { FiTrash2, FiUploadCloud } from "solid-icons/fi";
+import { Accessor, createMemo, createSignal, createUniqueId, Index, Setter, Show } from "solid-js";
+import { Alert, Button, ButtonVariant, Input, InputType, Modal, ModalContainer } from "~/components";
+import { Color } from "~/utils/color";
+
+interface EnvUploadModalProps {
+	isOpen: Accessor<boolean>;
+	setIsOpen: Setter<boolean>;
+	/** Keys already on the deployment, mapped to whether the existing value is secret-backed. */
+	existingKeys: Accessor<Map<string, boolean>>;
+	onSubmit: (entries: Array<{ key: string; value: string }>) => void;
+}
+
+type Row = { id: string; key: string; value: string };
+
+const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const makeDraft = (): Row => ({ id: createUniqueId(), key: "", value: "" });
+
+const unescapeDoubleQuoted = (s: string): string =>
+	s.replace(/\\(.)/g, (_, c) => {
+		switch (c) {
+			case "n":
+				return "\n";
+			case "r":
+				return "\r";
+			case "t":
+				return "\t";
+			case "\\":
+				return "\\";
+			case '"':
+				return '"';
+			default:
+				return c;
+		}
+	});
+
+const stripInlineComment = (s: string): string => {
+	// Drop the first " #" (or "\t#") and everything after it.
+	const m = s.match(/\s+#.*$/);
+	return m ? s.slice(0, m.index).trimEnd() : s.trimEnd();
+};
+
+export const parseDotEnv = (text: string): Array<{ key: string; value: string }> => {
+	const out = new Map<string, string>();
+	for (const rawLine of text.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (line === "" || line.startsWith("#")) continue;
+		const stripped = line.startsWith("export ") ? line.slice("export ".length).trimStart() : line;
+		const eq = stripped.indexOf("=");
+		if (eq < 0) continue;
+		const key = stripped.slice(0, eq).trim();
+		if (!KEY_RE.test(key)) continue;
+		let value = stripped.slice(eq + 1).trimStart();
+		if (value.length >= 2) {
+			const first = value[0];
+			const last = value[value.length - 1];
+			if (first === '"' && last === '"') {
+				value = unescapeDoubleQuoted(value.slice(1, -1));
+			} else if (first === "'" && last === "'") {
+				value = value.slice(1, -1);
+			} else {
+				value = stripInlineComment(value);
+			}
+		} else {
+			value = stripInlineComment(value);
+		}
+		out.set(key, value);
+	}
+	return Array.from(out, ([key, value]) => ({ key, value }));
+};
+
+const EnvUploadModal = (props: EnvUploadModalProps) => {
+	const [fileName, setFileName] = createSignal<string | null>(null);
+	const [rows, setRows] = createSignal<Row[]>([]);
+	const [isDragging, setIsDragging] = createSignal(false);
+	let fileInputRef: HTMLInputElement | undefined;
+
+	const reset = () => {
+		setFileName(null);
+		setRows([]);
+		if (fileInputRef) fileInputRef.value = "";
+	};
+
+	const ingestFile = async (file: File) => {
+		const text = await file.text();
+		const parsed = parseDotEnv(text);
+		const seeded: Row[] = parsed.map((p) => ({ id: createUniqueId(), ...p }));
+		seeded.push(makeDraft());
+		setFileName(file.name);
+		setRows(seeded);
+	};
+
+	const onFileChange = async (e: Event & { currentTarget: HTMLInputElement }) => {
+		const file = e.currentTarget.files?.[0];
+		if (!file) return;
+		await ingestFile(file);
+	};
+
+	const onDrop = async (e: DragEvent) => {
+		e.preventDefault();
+		setIsDragging(false);
+		const file = e.dataTransfer?.files?.[0];
+		if (!file) return;
+		await ingestFile(file);
+	};
+
+	const updateRow = (id: string, patch: Partial<Pick<Row, "key" | "value">>) => {
+		setRows((prev) => {
+			const next = prev.map((r) => (r.id === id ? { ...r, ...patch } : r));
+			const last = next[next.length - 1];
+			if (!last || last.key !== "" || last.value !== "") next.push(makeDraft());
+			return next;
+		});
+	};
+
+	const removeRow = (id: string) => {
+		setRows((prev) => {
+			const next = prev.filter((r) => r.id !== id);
+			const last = next[next.length - 1];
+			if (!last || last.key !== "" || last.value !== "") next.push(makeDraft());
+			return next;
+		});
+	};
+
+	const keyCounts = createMemo(() => {
+		const m = new Map<string, number>();
+		for (const r of rows()) {
+			if (r.key === "") continue;
+			m.set(r.key, (m.get(r.key) ?? 0) + 1);
+		}
+		return m;
+	});
+
+	type RowErrs = { key?: string; value?: string };
+	const rowError = (row: Row): RowErrs => {
+		const errs: RowErrs = {};
+		const keyEmpty = row.key === "";
+		const valEmpty = row.value === "";
+		if (keyEmpty && valEmpty) return errs;
+		if (keyEmpty) errs.key = "Key required";
+		else if (!KEY_RE.test(row.key)) errs.key = "Invalid key";
+		else if ((keyCounts().get(row.key) ?? 0) > 1) errs.key = "Duplicate key";
+		else if (props.existingKeys().get(row.key) === true)
+			errs.key = "Bound to a secret — remove this row to keep it";
+		if (valEmpty) errs.value = "Value required";
+		return errs;
+	};
+
+	// Collides with an existing plain value: overwriting is the point of uploading
+	// a .env, so this informs rather than blocks.
+	const rowWarning = (row: Row): string | undefined => {
+		if (rowError(row).key) return undefined;
+		if (row.key === "") return undefined;
+		return props.existingKeys().get(row.key) === false ? "Will update existing value" : undefined;
+	};
+
+	const hasError = createMemo(() => rows().some((r) => Object.keys(rowError(r)).length > 0));
+	const nonEmptyCount = createMemo(() => rows().filter((r) => r.key !== "" || r.value !== "").length);
+	const canSubmit = () => fileName() !== null && !hasError() && nonEmptyCount() > 0;
+
+	const handleSubmit = () => {
+		const entries: Array<{ key: string; value: string }> = [];
+		for (const r of rows()) {
+			if (r.key === "" || r.value === "") continue;
+			entries.push({ key: r.key, value: r.value });
+		}
+		props.onSubmit(entries);
+		props.setIsOpen(false);
+		reset();
+	};
+
+	const handleClose = () => {
+		props.setIsOpen(false);
+		reset();
+	};
+
+	return (
+		<Modal
+			isOpen={props.isOpen}
+			setIsOpen={props.setIsOpen}
+			renderTrigger={() => <></>}
+			renderModalContent={() => (
+				<ModalContainer closeFn={handleClose} width="min(640px, 100%)" class="max-h-[80vh] overflow-y-auto">
+					<h2 class="text-lg text-primary font-semibold mb-1">Upload .env file</h2>
+					<p class="text-sm text-white mb-4">We'll parse it and let you review before adding.</p>
+
+					<Show
+						when={fileName() !== null}
+						fallback={
+							<>
+								<input
+									ref={fileInputRef}
+									type="file"
+									accept=".env,text/plain"
+									class="hidden"
+									onChange={onFileChange}
+								/>
+								<div
+									role="button"
+									tabindex="0"
+									onClick={() => fileInputRef?.click()}
+									onKeyDown={(e) => {
+										if (e.key === "Enter" || e.key === " ") {
+											e.preventDefault();
+											fileInputRef?.click();
+										}
+									}}
+									onDragOver={(e) => {
+										e.preventDefault();
+										setIsDragging(true);
+									}}
+									onDragLeave={() => setIsDragging(false)}
+									onDrop={onDrop}
+									class={`flex flex-col items-center justify-center gap-3 px-6 py-10 border-2 border-dashed rounded-md cursor-pointer transition-colors ${isDragging()
+											? "border-primary bg-primary/8"
+											: "border-primary/30 hover:border-primary/60 hover:bg-primary/4"
+										}`}
+								>
+									<FiUploadCloud size={40} class="text-white" />
+									<div class="text-center">
+										<p class="text-base font-medium text-white">Drag a .env file here</p>
+										<p class="text-sm text-white/70 mt-1">
+											or <span class="underline">click to browse</span>
+										</p>
+									</div>
+								</div>
+							</>
+						}
+					>
+						<div class="flex items-center justify-between mb-3 text-sm">
+							<span class="text-white">
+								Parsed <strong>{nonEmptyCount()}</strong>{" "}
+								{nonEmptyCount() === 1 ? "variable" : "variables"} from{" "}
+								<span class="font-mono">{fileName()}</span>
+							</span>
+							<button type="button" class="text-primary hover:underline" onClick={reset}>
+								Choose a different file
+							</button>
+						</div>
+
+						<div class="flex flex-col gap-3 max-h-[50vh] overflow-y-auto pr-1">
+							<Index each={rows()}>
+								{(row) => {
+									const errs = () => rowError(row());
+									const warn = () => rowWarning(row());
+									const isDraftTrailing = () =>
+										row().key === "" &&
+										row().value === "" &&
+										rows()[rows().length - 1]?.id === row().id;
+									return (
+										<div class="flex flex-col gap-1">
+											<div class="flex flex-col sm:flex-row sm:items-center gap-3">
+												<Input
+													styleVariant="medium"
+													class={`flex-5 ${errs().key ? "border-error!" : ""}`}
+													placeholder="KEY"
+													type={InputType.Text}
+													value={row().key}
+													onInput={(e) => updateRow(row().id, { key: e.currentTarget.value })}
+												/>
+												<Input
+													styleVariant="medium"
+													class={`flex-7 ${errs().value ? "border-error!" : ""}`}
+													placeholder="value"
+													type={InputType.Text}
+													value={row().value}
+													onInput={(e) =>
+														updateRow(row().id, { value: e.currentTarget.value })
+													}
+												/>
+												<Show
+													when={!isDraftTrailing()}
+													fallback={<div class="hidden sm:block w-9" />}
+												>
+													<Button
+														type="button"
+														onClick={() => removeRow(row().id)}
+														variant={ButtonVariant.Outlined}
+														color={Color.Error}
+														class="h-full flex items-center justify-center"
+													>
+														<FiTrash2 size={16} />
+													</Button>
+												</Show>
+											</div>
+											<Show when={errs().key || errs().value || warn()}>
+												<div class="flex flex-col gap-0.5">
+													<Show when={errs().key}>
+														{(msg) => <Alert type="error" message={msg()} />}
+													</Show>
+													<Show when={errs().value}>
+														{(msg) => <Alert type="error" message={msg()} />}
+													</Show>
+													<Show when={warn()}>
+														{(msg) => <Alert type="warning" message={msg()} />}
+													</Show>
+												</div>
+											</Show>
+										</div>
+									);
+								}}
+							</Index>
+						</div>
+					</Show>
+
+					<div class="flex justify-between gap-3 mt-6">
+						<Button
+							type="button"
+							variant={ButtonVariant.Plain}
+							onClick={handleClose}
+							class="cursor-pointer"
+						>
+							Cancel
+						</Button>
+						<Button
+							type="button"
+							variant={ButtonVariant.Contained}
+							disabled={!canSubmit()}
+							onClick={handleSubmit}
+							class="cursor-pointer"
+						>
+							Add to deployment
+						</Button>
+					</div>
+				</ModalContainer>
+			)}
+		/>
+	);
+};
+
+export default EnvUploadModal;

--- a/frontend/src/routes/_logged-in/_workspaced/deployments/-components/env-upload-modal.tsx
+++ b/frontend/src/routes/_logged-in/_workspaced/deployments/-components/env-upload-modal.tsx
@@ -192,6 +192,7 @@ const EnvUploadModal = (props: EnvUploadModalProps) => {
 								<input
 									ref={fileInputRef}
 									type="file"
+									name="env-file"
 									accept=".env,text/plain"
 									class="hidden"
 									onChange={onFileChange}
@@ -212,10 +213,11 @@ const EnvUploadModal = (props: EnvUploadModalProps) => {
 									}}
 									onDragLeave={() => setIsDragging(false)}
 									onDrop={onDrop}
-									class={`flex flex-col items-center justify-center gap-3 px-6 py-10 border-2 border-dashed rounded-md cursor-pointer transition-colors ${isDragging()
+									class={`flex flex-col items-center justify-center gap-3 px-6 py-10 border-2 border-dashed rounded-md cursor-pointer transition-colors ${
+										isDragging()
 											? "border-primary bg-primary/8"
 											: "border-primary/30 hover:border-primary/60 hover:bg-primary/4"
-										}`}
+									}`}
 								>
 									<FiUploadCloud size={40} class="text-white" />
 									<div class="text-center">


### PR DESCRIPTION
Adds an "Upload your .env file" action to the deployment environment variable editor. The file is parsed client-side and shown in a review modal — editable keys/values, per-row delete — so nothing is added until you confirm.

Handles the usual `.env` shapes: comments, `export ` prefixes, single/double quotes, escapes, inline comments, and duplicate keys.

**On secrets:** a key already bound to a secret is flagged in red and blocks submit, so an upload can't silently swap a secret reference for a plain value. Keys colliding with an existing plain value warn but still apply — updating them is the point of re-uploading.

Originally written on `feat/beautification`, which was never merged and had no PR. Ported here on its own, without that branch's unrelated churn.

Frontend only; no API or schema changes. Typecheck and lint clean.