### PR TITLE
Align username min length across login and signup

### DIFF
--- a/e2e/specs/auth/login.spec.ts
+++ b/e2e/specs/auth/login.spec.ts
@@ -120,6 +120,25 @@ test.describe('login — server-side rejection', () => {
 		});
 	});
 
+	// Username min-length (2) is enforced client-side, matching sign-up and the
+	// backend's `length(min = 2)`. A single-char username blocks submit without
+	// firing a request.
+	test('single-char username blocks submit (no network request)', async ({ browser }) => {
+		await loginWith(browser, async (page) => {
+			let fired = false;
+			page.on('request', (req) => {
+				if (req.url().includes('/auth/sign-in')) fired = true;
+			});
+			await fillLoginForm(page, { userId: 'a', password: 'E2eTest!1Password' });
+			const submit = page.locator('button[type=submit]', { hasText: /^Login$/ });
+			await expect(submit).toBeEnabled({ timeout: 15_000 });
+			await submit.click();
+			await page.waitForTimeout(500);
+			expect(fired).toBe(false);
+			await expect(page.getByText(/at least 2 characters/i)).toBeVisible();
+		});
+	});
+
 	// SQLi-in-userId and case-sensitive-username rejection are API-contract
 	// behaviors covered in the Rust API suite (api/tests/api/auth.rs).
 });

--- a/e2e/specs/auth/signup.spec.ts
+++ b/e2e/specs/auth/signup.spec.ts
@@ -188,6 +188,20 @@ test.describe('sign-up — client-side field validation', () => {
 			await expect(page.getByText(/required/i).first()).toBeVisible();
 		});
 	});
+
+	// Username min-length (2) is enforced client-side, matching login and the
+	// backend's `length(min = 2)`. A single-char username blocks submit without
+	// firing a request.
+	test('single-char username blocks submit', async ({ browser }) => {
+		await withSignupContext(browser, async (page) => {
+			const creds = newCreds();
+			await fillSignupForm(page, { ...creds, username: 'a' });
+			await expectNoSignupRequest(page, async () => {
+				await submitSignup(page);
+			});
+			await expect(page.getByText(/at least 2 characters/i)).toBeVisible();
+		});
+	});
 });
 
 test.describe('sign-up — server-side rejection (bypass client validation)', () => {
@@ -259,7 +273,6 @@ test.describe('sign-up — server-side rejection (bypass client validation)', ()
 		['leading dot', '.baduser'],
 		['trailing dot', 'baduser.'],
 		['contains space', 'bad user'],
-		['single char', 'a'],
 	] as const) {
 		test(`username regex (${label}) → server rejects`, async ({ browser }) => {
 			await withSignupContext(browser, async (page) => {

--- a/frontend/src/routes/_logged-out/sign-up.tsx
+++ b/frontend/src/routes/_logged-out/sign-up.tsx
@@ -78,6 +78,9 @@ const SignUp = () => {
 		if (!username().trim()) {
 			newErrors.username = "Username is required.";
 			valid = false;
+		} else if (username().trim().length < 2) {
+			newErrors.username = "Must be at least 2 characters.";
+			valid = false;
 		}
 		const firstNameError = validateNameField(firstName());
 		if (firstNameError) {

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -225,7 +225,7 @@ export function validateRoleDescription(value: string): string | undefined {
  */
 export function validateUsernameOrEmail(value: string): string | undefined {
 	if (!value || value.trim().length === 0) return "Required";
-	if (value.length < 4) return "Must be at least 4 characters";
+	if (value.length < 2) return "Must be at least 2 characters";
 	if (value.includes("@")) {
 		if (!value.includes(".") || value.length < 5) {
 			return "Not a valid email address";


### PR DESCRIPTION
## Summary

The username minimum length was inconsistent between the two auth forms:

- **Login** rejected usernames under **4** characters (`validateUsernameOrEmail`).
- **Signup** enforced no minimum at all — only a non-empty check.

This aligns both to a **2-character** minimum, matching the backend's `length(min = 2)` on the sign-in and create-account endpoints.

- Login: lower the min from 4 → 2 in `validateUsernameOrEmail`.
- Signup: add a min-2 check to the username block (previously non-empty only).

## Test plan

- Added e2e specs asserting each form blocks a 1-char username client-side (no `/auth` request fires) and shows the "at least 2 characters" inline error.
- Moved the signup `single char` case out of the server-rejection loop — it's now blocked client-side, so it no longer reaches the server.
- Verified `tsc --noEmit` + frontend build (cloud mode) and prettier pass.
- Full e2e run to be done in CI/Linux (the API can't run on the local macOS host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)