### PR TITLE
Stop dropdowns opening upwards over the row that opened them

### DIFF
--- a/frontend/src/components/input-dropdown-checkbox.tsx
+++ b/frontend/src/components/input-dropdown-checkbox.tsx
@@ -1,9 +1,11 @@
 import { MaybeAccessor } from "~/utils/types";
 import { InputDropdownOption } from "./input-dropdown";
-import { createEffect, createSignal, For, JSX, mergeProps, Show } from "solid-js";
+import { createSignal, For, JSX, mergeProps, Show } from "solid-js";
+import { Portal } from "solid-js/web";
 import { get, variantBgClass } from "~/utils/func";
 import { FiChevronDown } from "solid-icons/fi";
 import { useClickOutside } from "~/hooks";
+import { createDropdownPosition } from "~/hooks/dropdown-position";
 import Checkbox from "./checkbox";
 
 interface InputDropdownCheckboxProps {
@@ -54,26 +56,20 @@ const InputDropdownCheckbox = (rawProps: InputDropdownCheckboxProps) => {
 	);
 
 	const [showDropdown, setShowDropdown] = createSignal(false);
+	const [containerRef, setContainerRef] = createSignal<HTMLDivElement>();
 	const [dropdownRef, setDropdownRef] = createSignal<HTMLDivElement>();
 	const [inputRef, setInputRef] = createSignal<HTMLInputElement>();
 	const [inputValue, setInputValue] = createSignal("");
 	const [highlightedIndex, setHighlightedIndex] = createSignal(-1);
-	const [dropDirection, setDropDirection] = createSignal<"down" | "up">("down");
 
-	const DROPDOWN_MAX_HEIGHT_PX = 240;
+	const dropdownRect = createDropdownPosition(containerRef, showDropdown);
 
-	useClickOutside(dropdownRef, () => {
+	// The list is portalled out of the container, so a click on an option counts
+	// as "outside" unless it is explicitly excluded here.
+	useClickOutside(containerRef, (event) => {
+		const dd = dropdownRef();
+		if (dd && dd.contains(event.target as Node)) return;
 		setShowDropdown(false);
-	});
-
-	createEffect(() => {
-		if (!showDropdown()) return;
-		const el = dropdownRef();
-		if (!el || typeof window === "undefined") return;
-		const rect = el.getBoundingClientRect();
-		const spaceBelow = window.innerHeight - rect.bottom;
-		const spaceAbove = rect.top;
-		setDropDirection(spaceBelow < DROPDOWN_MAX_HEIGHT_PX && spaceAbove > spaceBelow ? "up" : "down");
 	});
 
 	const containerClass = () => `rounded-xs flex justify-start
@@ -82,7 +78,7 @@ const InputDropdownCheckbox = (rawProps: InputDropdownCheckboxProps) => {
     ${showDropdown() ? "border-primary shadow-md bg-secondary-light" : ""}
 		focus-within:border-primary focus-within:shadow-md focus-within:bg-secondary-light
 		${variantBgClass(get(props.styleVariant))} ${get(props.class)} ${
-			showDropdown() ? (dropDirection() === "up" ? "rounded-t-none" : "rounded-b-none") : ""
+			showDropdown() ? (dropdownRect().direction === "up" ? "rounded-t-none" : "rounded-b-none") : ""
 		}`;
 
 	const onSelectItem = (e: MouseEvent, value: string) => {
@@ -158,7 +154,7 @@ const InputDropdownCheckbox = (rawProps: InputDropdownCheckboxProps) => {
 	};
 
 	return (
-		<div ref={setDropdownRef} onClick={() => setShowDropdown((prev) => !prev)} class={containerClass()}>
+		<div ref={setContainerRef} onClick={() => setShowDropdown((prev) => !prev)} class={containerClass()}>
 			<input
 				ref={setInputRef}
 				required={props.required}
@@ -176,44 +172,58 @@ const InputDropdownCheckbox = (rawProps: InputDropdownCheckboxProps) => {
 			<FiChevronDown class="mr-sm" />
 
 			{showDropdown() && (
-				<div
-					class={`${variantBgClass(
-						get(props.styleVariant)
-					)} border border-border-color absolute z-10 -left-px w-[calc(100%+2px)] rounded-xs shadow-lg overflow-y-scroll max-h-60 ${
-						dropDirection() === "up" ? "bottom-[2.22rem] rounded-b-none" : "top-[2.22rem] rounded-t-none"
-					}`}
-					onScroll={(e) => {
-						if (!props.onLoadMore) return;
-						const el = e.currentTarget;
-						if (el.scrollHeight - el.scrollTop - el.clientHeight < 40) {
-							props.onLoadMore();
-						}
-					}}
-				>
-					<For each={filteredOptions()}>
-						{(option, index) => (
-							<div
-								onClick={(e) => onSelectItem(e, option.value)}
-								class={`border-b last-of-type:border-0 border-border-color px-xl py-sm cursor-pointer flex items-center gap-3 ${
-									highlightedIndex() === index() ? "bg-secondary-dark" : ""
-								}`}
-							>
-								<div class="pointer-events-none">
-									<Checkbox
-										checked={get(props.checked).includes(option.value)}
-										label={option.label}
-									/>
+				<Portal>
+					<div
+						ref={setDropdownRef}
+						style={{
+							position: "fixed",
+							...(dropdownRect().direction === "up"
+								? { bottom: `${dropdownRect().bottomOffset}px` }
+								: { top: `${dropdownRect().top}px` }),
+							left: `${dropdownRect().left}px`,
+							width: `${dropdownRect().width}px`,
+							"max-height": `${dropdownRect().maxHeight}px`,
+						}}
+						class={`${variantBgClass(
+							get(props.styleVariant)
+						)} border border-border-color z-50 rounded-xs shadow-lg overflow-y-auto ${
+							dropdownRect().direction === "up" ? "rounded-b-none" : "rounded-t-none"
+						}`}
+						onScroll={(e) => {
+							if (!props.onLoadMore) return;
+							const el = e.currentTarget;
+							if (el.scrollHeight - el.scrollTop - el.clientHeight < 40) {
+								props.onLoadMore();
+							}
+						}}
+					>
+						<For each={filteredOptions()}>
+							{(option, index) => (
+								<div
+									onClick={(e) => onSelectItem(e, option.value)}
+									class={`border-b last-of-type:border-0 border-border-color px-xl py-sm cursor-pointer flex items-center gap-3 ${
+										highlightedIndex() === index() ? "bg-secondary-dark" : ""
+									}`}
+								>
+									<div class="pointer-events-none">
+										<Checkbox
+											checked={get(props.checked).includes(option.value)}
+											label={option.label}
+										/>
+									</div>
 								</div>
-							</div>
+							)}
+						</For>
+						{filteredOptions().length === 0 && (
+							<div class="px-xl py-sm text-grey">No options available.</div>
 						)}
-					</For>
-					{filteredOptions().length === 0 && <div class="px-xl py-sm text-grey">No options available.</div>}
-					<Show when={get(props.isLoadingMore)}>
-						<div class="flex items-center justify-center py-sm">
-							<div class="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-						</div>
-					</Show>
-				</div>
+						<Show when={get(props.isLoadingMore)}>
+							<div class="flex items-center justify-center py-sm">
+								<div class="w-4 h-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+							</div>
+						</Show>
+					</div>
+				</Portal>
 			)}
 		</div>
 	);

--- a/frontend/src/components/input.tsx
+++ b/frontend/src/components/input.tsx
@@ -1,7 +1,8 @@
 import { FiChevronDown, FiEye, FiEyeOff } from "solid-icons/fi";
-import { createEffect, createSignal, For, mergeProps, onCleanup, Show, JSX } from "solid-js";
+import { createSignal, For, mergeProps, Show, JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { useClickOutside } from "~/hooks";
+import { createDropdownPosition } from "~/hooks/dropdown-position";
 import { get, variantBgClass } from "~/utils/func";
 import { MaybeAccessor } from "~/utils/types";
 
@@ -214,49 +215,7 @@ const Input = (rawProps: InputProps) => {
 	const [highlightedIndex, setHighlightedIndex] = createSignal(-1);
 	const [containerRef, setContainerRef] = createSignal<HTMLDivElement>();
 	const [dropdownRef, setDropdownRef] = createSignal<HTMLDivElement>();
-	const [dropdownRect, setDropdownRect] = createSignal<{
-		top: number;
-		left: number;
-		width: number;
-		bottomOffset: number;
-		direction: "down" | "up";
-	}>({
-		top: 0,
-		left: 0,
-		width: 0,
-		bottomOffset: 0,
-		direction: "down",
-	});
-
-	const DROPDOWN_MAX_HEIGHT_PX = 240;
-
-	const updateDropdownRect = () => {
-		const el = containerRef();
-		if (!el || typeof window === "undefined") return;
-		const rect = el.getBoundingClientRect();
-		const spaceBelow = window.innerHeight - rect.bottom;
-		const spaceAbove = rect.top;
-		const direction = spaceBelow < DROPDOWN_MAX_HEIGHT_PX && spaceAbove > spaceBelow ? "up" : "down";
-		setDropdownRect({
-			top: rect.bottom,
-			left: rect.left,
-			width: rect.width,
-			bottomOffset: window.innerHeight - rect.top,
-			direction,
-		});
-	};
-
-	createEffect(() => {
-		if (!showDropdown()) return;
-		updateDropdownRect();
-		const onResizeOrScroll = () => updateDropdownRect();
-		window.addEventListener("scroll", onResizeOrScroll, true);
-		window.addEventListener("resize", onResizeOrScroll);
-		onCleanup(() => {
-			window.removeEventListener("scroll", onResizeOrScroll, true);
-			window.removeEventListener("resize", onResizeOrScroll);
-		});
-	});
+	const dropdownRect = createDropdownPosition(containerRef, showDropdown);
 
 	useClickOutside(containerRef, (event) => {
 		const dd = dropdownRef();
@@ -453,10 +412,11 @@ const Input = (rawProps: InputProps) => {
 								: { top: `${dropdownRect().top}px` }),
 							left: `${dropdownRect().left}px`,
 							width: `${dropdownRect().width}px`,
+							"max-height": `${dropdownRect().maxHeight}px`,
 						}}
 						class={`${variantBgClass(
 							get(props.styleVariant)
-						)} border border-border-color z-50 rounded-xs shadow-lg overflow-y-scroll max-h-60 ${
+						)} border border-border-color z-50 rounded-xs shadow-lg overflow-y-auto ${
 							dropdownRect().direction === "up" ? "rounded-b-none" : "rounded-t-none"
 						}`}
 					>

--- a/frontend/src/hooks/dropdown-position.ts
+++ b/frontend/src/hooks/dropdown-position.ts
@@ -1,0 +1,105 @@
+import { Accessor, createEffect, createSignal, onCleanup } from "solid-js";
+
+/** How tall a dropdown may grow before its contents scroll. */
+const MAX_HEIGHT_PX = 240;
+/**
+ * The least room worth opening downwards into. Above this the list just scrolls
+ * in whatever space is left; below it there are too few visible rows to pick
+ * from and flipping above the anchor is the better trade.
+ */
+const MIN_USABLE_PX = 144;
+/** Gap kept between the dropdown and the edge of the viewport. */
+const VIEWPORT_MARGIN_PX = 8;
+
+/** Where a portalled dropdown should sit, in viewport coordinates. */
+export interface DropdownPosition {
+	/** Viewport `top` for a downwards dropdown. */
+	top: number;
+	left: number;
+	width: number;
+	/** Viewport `bottom` for an upwards dropdown. */
+	bottomOffset: number;
+	direction: "down" | "up";
+	/** Height cap, so the list scrolls instead of running off-screen. */
+	maxHeight: number;
+}
+
+/**
+ * Positions a dropdown against its anchor, re-measuring while it is open.
+ *
+ * Opening downwards is strongly preferred. Flipping upwards merely because the
+ * full height doesn't fit means a dropdown covers whatever sits above it — in a
+ * stack of binding rows that is the row being edited, which is exactly what the
+ * user is trying to look at. So it only flips when the space below is too small
+ * to show a usable number of rows, and otherwise caps its height and scrolls.
+ *
+ * Meant to be rendered through a `<Portal>` with `position: fixed`, so no
+ * ancestor's `overflow` or stacking context can clip it.
+ */
+export const createDropdownPosition = (
+	anchor: Accessor<HTMLElement | undefined>,
+	isOpen: Accessor<boolean>
+): Accessor<DropdownPosition> => {
+	const [position, setPosition] = createSignal<DropdownPosition>({
+		top: 0,
+		left: 0,
+		width: 0,
+		bottomOffset: 0,
+		direction: "down",
+		maxHeight: MAX_HEIGHT_PX,
+	});
+
+	const measure = () => {
+		const el = anchor();
+		if (!el || typeof window === "undefined") return;
+
+		const rect = el.getBoundingClientRect();
+		const spaceBelow = window.innerHeight - rect.bottom - VIEWPORT_MARGIN_PX;
+		const spaceAbove = rect.top - VIEWPORT_MARGIN_PX;
+		const flip = spaceBelow < MIN_USABLE_PX && spaceAbove > spaceBelow;
+
+		setPosition({
+			top: rect.bottom,
+			left: rect.left,
+			width: rect.width,
+			bottomOffset: window.innerHeight - rect.top,
+			direction: flip ? "up" : "down",
+			maxHeight: Math.max(0, Math.min(MAX_HEIGHT_PX, flip ? spaceAbove : spaceBelow)),
+		});
+	};
+
+	/**
+	 * Scrolls the anchor towards the middle of the viewport when there isn't
+	 * room to open downwards. Flipping is the fallback, not the goal — an
+	 * upwards dropdown covers whatever the user was just looking at, and near
+	 * the bottom of a page there is usually scroll left to spend instead. A
+	 * no-op when the page is already scrolled as far as it goes, which is
+	 * exactly when flipping is the right answer.
+	 */
+	const ensureRoomBelow = () => {
+		const el = anchor();
+		if (!el || typeof window === "undefined") return;
+		const rect = el.getBoundingClientRect();
+		if (window.innerHeight - rect.bottom - VIEWPORT_MARGIN_PX >= MIN_USABLE_PX) return;
+		el.scrollIntoView({ block: "center", behavior: "smooth" });
+	};
+
+	createEffect(() => {
+		if (!isOpen()) return;
+		ensureRoomBelow();
+		measure();
+		const onMove = () => measure();
+		// Capture phase: the anchor may sit inside a scrollable panel whose
+		// scroll events never reach the window otherwise.
+		window.addEventListener("scroll", onMove, true);
+		window.addEventListener("resize", onMove);
+		onCleanup(() => {
+			window.removeEventListener("scroll", onMove, true);
+			window.removeEventListener("resize", onMove);
+		});
+	});
+
+	return position;
+};
+
+export default createDropdownPosition;


### PR DESCRIPTION
- Flip only when there is genuinely no room below, and cap the height instead of demanding the full 240px
- Scroll the anchor into view first, so there usually is room
- Portal the checkbox dropdown so it cannot be clipped by an ancestor's overflow or sit underneath a sibling