### PR TITLE
Let a page fill the viewport and scroll its panels instead

### DIFF
--- a/frontend/src/components/page/body.tsx
+++ b/frontend/src/components/page/body.tsx
@@ -9,6 +9,11 @@ interface PageContainerBodyProps {
 	class?: MaybeAccessor<string>;
 }
 
+/*
+ * `flex-1 min-h-0`, not `h-full`: as a flex item, `height: 100%` gets shrunk to
+ * fit beside the head and collapses to a few pixels once the page is bound to
+ * the viewport. `min-h-0` is what lets it scroll instead of growing.
+ */
 const PageContainerBody = (rawProps: ParentProps<PageContainerBodyProps>) => {
 	const props = mergeProps(
 		{
@@ -18,8 +23,8 @@ const PageContainerBody = (rawProps: ParentProps<PageContainerBodyProps>) => {
 	);
 
 	return (
-		<section class="h-full bg-secondary-dark p-sm md:p-md rounded-b-xs text-white flex-1 text-sm relative flex flex-col">
-			<div class={`mx-auto w-full max-w-300 flex-1 ${get(props.class)}`}>{props.children}</div>
+		<section class="min-h-0 bg-secondary-dark p-sm md:p-md rounded-b-xs text-white flex-1 text-sm relative flex flex-col">
+			<div class={`mx-auto w-full max-w-300 flex-1 min-h-0 ${get(props.class)}`}>{props.children}</div>
 		</section>
 	);
 };

--- a/frontend/src/components/page/container.tsx
+++ b/frontend/src/components/page/container.tsx
@@ -5,14 +5,28 @@ import { MaybeAccessor } from "~/utils/types";
 interface PageContainerProps {
 	/** Additional Classes to add */
 	class?: MaybeAccessor<string>;
+	/**
+	 * Bound the page to the viewport instead of growing with its content, so
+	 * that panels inside it can scroll on their own. A prop rather than a class
+	 * the caller passes, because the default is `min-height` — two competing
+	 * height utilities on one element resolve by stylesheet order, not by the
+	 * order they appear in the class list, so overriding it from outside is a
+	 * coin flip.
+	 */
+	fillViewport?: MaybeAccessor<boolean>;
 }
 
 const PageContainer = (rawProps: ParentProps<PageContainerProps>) => {
 	const props = mergeProps({}, rawProps);
 
+	const heightClass = () =>
+		get(props.fillViewport)
+			? "h-full min-h-0 overflow-hidden"
+			: "min-h-[calc(100vh-56px)] md:min-h-[calc(100vh-64px)]";
+
 	return (
 		<div
-			class={`min-h-[calc(100vh-56px)] md:min-h-[calc(100vh-64px)] ${get(props.class) || ""} bg-secondary p-xs md:p-sm md:pl-0 md:ml-sm flex flex-col`}
+			class={`${heightClass()} ${get(props.class) || ""} bg-secondary p-xs md:p-sm md:pl-0 md:ml-sm flex flex-col`}
 		>
 			{props.children}
 		</div>

--- a/frontend/src/components/page/head.tsx
+++ b/frontend/src/components/page/head.tsx
@@ -86,7 +86,11 @@ const PageContainerHead = (rawProps: PageContainerHeadProps) => {
 
 	return (
 		<>
-			<header class={`h-full bg-secondary-light rounded-t-xs p-md py-md md:p-xl md:py-lg ${props.class}`}>
+			{/* `shrink-0`, not `h-full`: the head is a flex item and `height: 100%`
+			  made it claim the whole container, leaving the body a few pixels once
+			  a page stopped growing with its content. It only ever wanted its
+			  natural height. */}
+			<header class={`shrink-0 bg-secondary-light rounded-t-xs p-md py-md md:p-xl md:py-lg ${props.class}`}>
 				<div class="mx-auto w-full max-w-300 flex flex-col items-start gap-3 md:flex-row md:justify-between md:items-center md:gap-2">
 					<div class="flex flex-col gap-2 justify-start min-w-0 w-full md:w-auto">
 						<div class="flex gap-4 items-center select-none flex-wrap">

--- a/frontend/src/components/pagination.tsx
+++ b/frontend/src/components/pagination.tsx
@@ -16,6 +16,13 @@ interface PaginationProps {
 	loading?: MaybeAccessor<boolean>;
 	/** Additional classes for the root element */
 	class?: MaybeAccessor<string>;
+	/**
+	 * Rows pinned outside the paginated set and rendered only on the first page
+	 * (the members page pins the workspace owner and every pending invite).
+	 * They count toward the total and shift the displayed range, but not the
+	 * page math — that still belongs to the paginated list alone.
+	 */
+	pinnedCount?: MaybeAccessor<number>;
 }
 
 /**
@@ -72,8 +79,13 @@ const Pagination = (rawProps: PaginationProps) => {
 
 	const pageWindow = () => buildPageWindow(props.state.page(), props.state.totalPages());
 
-	const rangeStart = () => props.state.page() * props.state.count() + 1;
-	const rangeEnd = () => Math.min((props.state.page() + 1) * props.state.count(), props.state.totalCount());
+	const pinned = () => get(props.pinnedCount) ?? 0;
+	const totalCount = () => props.state.totalCount() + pinned();
+
+	// The pinned rows all sit on page 0, so they shift every later page's range
+	// along by their count without ever being part of one.
+	const rangeStart = () => props.state.page() * props.state.count() + 1 + (props.state.page() === 0 ? 0 : pinned());
+	const rangeEnd = () => Math.min((props.state.page() + 1) * props.state.count() + pinned(), totalCount());
 
 	const btnBase =
 		"h-8 flex items-center justify-center rounded-xs text-sm font-medium transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed";
@@ -88,12 +100,12 @@ const Pagination = (rawProps: PaginationProps) => {
 		>
 			{/* Left: item range label */}
 			<p class="text-sm text-grey flex-1">
-				<Show when={props.state.totalCount() > 0} fallback={<span>No results</span>}>
+				<Show when={totalCount() > 0} fallback={<span>No results</span>}>
 					Showing&nbsp;
 					<span class="text-white">
 						{rangeStart()}–{rangeEnd()}
 					</span>
-					&nbsp;of <span class="text-white">{props.state.totalCount()}</span>
+					&nbsp;of <span class="text-white">{totalCount()}</span>
 				</Show>
 			</p>
 


### PR DESCRIPTION
- `PageContainer` takes a `fillViewport` prop. A prop rather than a class the caller passes, because the default is `min-height` and two competing height utilities resolve by stylesheet order, not by the order they appear in the class list
- The head and body stop using `h-full`, which as flex items made them fight over the page — the head was claiming all of it
- `Pagination` takes `pinnedCount` for rows that live outside the paginated set